### PR TITLE
Support reverse-proxy base paths via --base-path for headless deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,16 @@ Notes:
 - depending on proxying details, authentication behavior may differ from direct remote access
 - if conversations created in the web UI do not immediately appear in the Windows app, restarting the Windows app may refresh them
 
+### Reverse proxy path prefix
+
+Set `CODEXUI_BASE_PATH` when a reverse proxy exposes each Codex UI instance below a workspace-specific path:
+
+```bash
+CODEXUI_BASE_PATH=/codex/<workspace-id> npx codexapp --no-tunnel --port 5900
+```
+
+The browser then uses URLs such as `/codex/<workspace-id>/codex-api/rpc` and `/codex/<workspace-id>/codex-api/ws` for HTTP and WebSocket traffic. Assets, the web manifest, service worker, local-file routes, and login requests use the same prefix. The server accepts both prefixed requests and unprefixed requests, so an ingress may use the prefix to select a workspace and strip it before forwarding upstream.
+
 ---
 
 ## ✨ Features

--- a/README.md
+++ b/README.md
@@ -124,10 +124,10 @@ Notes:
 
 ### Reverse proxy path prefix
 
-Set `CODEXUI_BASE_PATH` when a reverse proxy exposes each Codex UI instance below a workspace-specific path:
+Pass `--base-path` when a reverse proxy exposes each Codex UI instance below a workspace-specific path:
 
 ```bash
-CODEXUI_BASE_PATH=/codex/<workspace-id> npx codexapp --no-tunnel --port 5900
+npx codexapp --base-path /codex/<workspace-id> --no-tunnel --port 5900
 ```
 
 The browser then uses URLs such as `/codex/<workspace-id>/codex-api/rpc` and `/codex/<workspace-id>/codex-api/ws` for HTTP and WebSocket traffic. Assets, the web manifest, service worker, local-file routes, and login requests use the same prefix. The server accepts both prefixed requests and unprefixed requests, so an ingress may use the prefix to select a workspace and strip it before forwarding upstream.

--- a/index.html
+++ b/index.html
@@ -7,14 +7,15 @@
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <meta name="apple-mobile-web-app-title" content="Codex Web" />
-    <link rel="manifest" href="/manifest.webmanifest" />
-    <link rel="icon" type="image/svg+xml" href="/icons/codexui-icon.svg" />
-    <link rel="icon" type="image/png" sizes="192x192" href="/icons/pwa-192x192.png" />
-    <link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon.png" />
+    <meta name="codexui-base-path" content="__CODEXUI_BASE_PATH__" />
+    <link rel="manifest" href="./manifest.webmanifest" />
+    <link rel="icon" type="image/svg+xml" href="./icons/codexui-icon.svg" />
+    <link rel="icon" type="image/png" sizes="192x192" href="./icons/pwa-192x192.png" />
+    <link rel="apple-touch-icon" sizes="180x180" href="./icons/apple-touch-icon.png" />
     <title>Codex Web</title>
   </head>
   <body class="bg-slate-950">
     <div id="app"></div>
-    <script type="module" src="/src/main.ts"></script>
+    <script type="module" src="./src/main.ts"></script>
   </body>
 </html>

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -2,32 +2,32 @@
   "name": "Codex Web",
   "short_name": "Codex Web",
   "description": "A lightweight web interface for Codex that can be installed like an app in Chrome.",
-  "start_url": "/",
-  "scope": "/",
+  "start_url": ".",
+  "scope": ".",
   "display": "standalone",
   "background_color": "#020617",
   "theme_color": "#020617",
   "icons": [
     {
-      "src": "/icons/pwa-192x192.png",
+      "src": "icons/pwa-192x192.png",
       "sizes": "192x192",
       "type": "image/png",
       "purpose": "any"
     },
     {
-      "src": "/icons/pwa-512x512.png",
+      "src": "icons/pwa-512x512.png",
       "sizes": "512x512",
       "type": "image/png",
       "purpose": "any"
     },
     {
-      "src": "/icons/apple-touch-icon.png",
+      "src": "icons/apple-touch-icon.png",
       "sizes": "180x180",
       "type": "image/png",
       "purpose": "any"
     },
     {
-      "src": "/icons/maskable-512x512.png",
+      "src": "icons/maskable-512x512.png",
       "sizes": "512x512",
       "type": "image/png",
       "purpose": "maskable"

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,7 +1,9 @@
-const CACHE_NAME = 'codexweb-shell-v2'
-const APP_SHELL_PATHS = ['/', '/manifest.webmanifest']
+const BASE_PATH = new URL('./', self.registration.scope).pathname.replace(/\/$/, '')
+const CACHE_NAME = `codexweb-shell-v3:${BASE_PATH || '/'}`
+const APP_SHELL_PATHS = [`${BASE_PATH}/`, `${BASE_PATH}/manifest.webmanifest`]
 const STATIC_DESTINATIONS = new Set(['document', 'script', 'style', 'image', 'font'])
 const BYPASS_PREFIXES = ['/codex-api/', '/codex-local-image', '/codex-local-file', '/codex-local-browse/', '/codex-local-edit/']
+  .map((path) => `${BASE_PATH}${path}`)
 
 self.addEventListener('install', (event) => {
   event.waitUntil(
@@ -15,7 +17,9 @@ self.addEventListener('activate', (event) => {
     caches.keys().then((keys) =>
       Promise.all(
         keys
-          .filter((key) => key !== CACHE_NAME)
+          .filter((key) => key !== CACHE_NAME && key.startsWith('codexweb-shell-v') && (
+            key.endsWith(`:${BASE_PATH || '/'}`) || (BASE_PATH === '' && key === 'codexweb-shell-v2')
+          ))
           .map((key) => caches.delete(key)),
       ),
     ),
@@ -41,7 +45,7 @@ self.addEventListener('fetch', (event) => {
     return
   }
 
-  if (STATIC_DESTINATIONS.has(request.destination) || url.pathname === '/manifest.webmanifest') {
+  if (STATIC_DESTINATIONS.has(request.destination) || url.pathname === `${BASE_PATH}/manifest.webmanifest`) {
     event.respondWith(staleWhileRevalidate(request))
   }
 })
@@ -50,10 +54,10 @@ async function networkFirstNavigation(request) {
   const cache = await caches.open(CACHE_NAME)
   try {
     const response = await fetch(request)
-    cache.put('/', response.clone())
+    cache.put(`${BASE_PATH}/`, response.clone())
     return response
   } catch {
-    return (await cache.match('/')) || Response.error()
+    return (await cache.match(`${BASE_PATH}/`)) || Response.error()
   }
 }
 

--- a/scripts/dev.cjs
+++ b/scripts/dev.cjs
@@ -30,6 +30,30 @@ function run(command, args, options = {}) {
   process.exit(result.status ?? 1)
 }
 
+function extractBasePath(args) {
+  let basePath = ''
+  const passthrough = []
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index]
+    if (arg === '--base-path') {
+      const value = args[index + 1]
+      if (!value || value.startsWith('-')) {
+        throw new Error('Missing value for --base-path')
+      }
+      basePath = value
+      index += 1
+      continue
+    }
+    if (arg.startsWith('--base-path=')) {
+      basePath = arg.slice('--base-path='.length)
+      if (!basePath) throw new Error('Missing value for --base-path')
+      continue
+    }
+    passthrough.push(arg)
+  }
+  return { basePath, passthrough }
+}
+
 const passthroughArgs = process.argv.slice(2)
 const viteBinPath = join(process.cwd(), 'node_modules', '.bin', process.platform === 'win32' ? 'vite.cmd' : 'vite')
 const vueTscBinPath = join(process.cwd(), 'node_modules', '.bin', process.platform === 'win32' ? 'vue-tsc.cmd' : 'vue-tsc')
@@ -59,4 +83,10 @@ if (!existsSync(viteBinPath) || !existsSync(vueTscBinPath)) {
   }
 }
 
-run(viteBinPath, passthroughArgs)
+const { basePath, passthrough } = extractBasePath(passthroughArgs)
+run(viteBinPath, passthrough, {
+  env: {
+    ...process.env,
+    VITE_CODEXUI_BASE_PATH: basePath,
+  },
+})

--- a/src/App.vue
+++ b/src/App.vue
@@ -1231,6 +1231,7 @@ import type { GitCommitFileChange, GitCommitOption, LocalDirectoryEntry, Telegra
 import { getFreeModeStatus, setFreeMode, setFreeModeCustomKey, setCustomProvider } from './api/codexGateway'
 import { getPathLeafName, getPathParent, isProjectlessChatPath, normalizePathForUi } from './pathUtils.js'
 import { copyTextToClipboard } from './utils/clipboard'
+import { appPath } from './basePath'
 
 const ThreadConversation = defineAsyncComponent(() => import('./components/content/ThreadConversation.vue'))
 const ThreadTerminalPanel = defineAsyncComponent(() => import('./components/content/ThreadTerminalPanel.vue'))
@@ -2787,7 +2788,7 @@ function onBrowseThreadFiles(threadId: string): void {
     }
   }
   if (!targetCwd || typeof window === 'undefined') return
-  window.open(`/codex-local-browse${encodeURI(targetCwd)}`, '_blank', 'noopener,noreferrer')
+  window.open(appPath(`/codex-local-browse${encodeURI(targetCwd)}`), '_blank', 'noopener,noreferrer')
 }
 
 function getProjectCwd(projectName: string): string {
@@ -2819,7 +2820,7 @@ function toWorktreeFolderNameDraft(projectName: string): string {
 function onBrowseProjectFiles(projectName: string): void {
   const targetCwd = getProjectCwd(projectName)
   if (!targetCwd || typeof window === 'undefined') return
-  window.open(`/codex-local-browse${encodeURI(targetCwd)}`, '_blank', 'noopener,noreferrer')
+  window.open(appPath(`/codex-local-browse${encodeURI(targetCwd)}`), '_blank', 'noopener,noreferrer')
 }
 
 async function onSaveProject(projectName: string): Promise<void> {

--- a/src/api/codexGateway.ts
+++ b/src/api/codexGateway.ts
@@ -57,6 +57,7 @@ import type {
   UiThreadAutomationStatus,
 } from '../types/codex'
 import { normalizePathForUi } from '../pathUtils.js'
+import { appFetch, appPath, stripAppBasePath } from '../basePath'
 
 type CurrentModelConfig = {
   model: string
@@ -620,7 +621,7 @@ function readThreadTurnStartIndex(payload: ThreadReadResponse): number {
 }
 
 async function fetchThreadFileChangeFallback(threadId: string): Promise<ThreadFileChangeFallbackEntry[]> {
-  const response = await fetch(`/codex-api/thread-file-change-fallback?threadId=${encodeURIComponent(threadId)}`)
+  const response = await appFetch(`/codex-api/thread-file-change-fallback?threadId=${encodeURIComponent(threadId)}`)
   if (!response.ok) {
     throw new Error(`Fallback request failed with ${response.status}`)
   }
@@ -793,7 +794,7 @@ async function getOlderThreadMessagesV2(threadId: string, beforeTurnId: string, 
     beforeTurnId,
     limit: String(limit),
   })
-  const response = await fetch(`/codex-api/thread-turn-page?${params.toString()}`)
+  const response = await appFetch(`/codex-api/thread-turn-page?${params.toString()}`)
   if (!response.ok) {
     throw new Error(`Older thread page request failed with ${response.status}`)
   }
@@ -1152,7 +1153,7 @@ function asAutomationArray(value: unknown): UiThreadAutomation[] {
 }
 
 export async function getThreadAutomationMap(): Promise<Record<string, UiThreadAutomation[]>> {
-  const response = await fetch('/codex-api/thread-automations')
+  const response = await appFetch('/codex-api/thread-automations')
   const payload = await response.json().catch(() => null)
   if (!response.ok) {
     throw new Error(extractErrorMessage(payload, 'Failed to load thread automations'))
@@ -1168,7 +1169,7 @@ export async function getThreadAutomationMap(): Promise<Record<string, UiThreadA
 }
 
 export async function getProjectAutomationMap(): Promise<Record<string, UiThreadAutomation[]>> {
-  const response = await fetch('/codex-api/project-automations')
+  const response = await appFetch('/codex-api/project-automations')
   const payload = await response.json().catch(() => null)
   if (!response.ok) {
     throw new Error(extractErrorMessage(payload, 'Failed to load project automations'))
@@ -1186,7 +1187,7 @@ export async function getProjectAutomationMap(): Promise<Record<string, UiThread
 export async function getThreadAutomation(threadId: string, automationId?: string): Promise<UiThreadAutomation | null> {
   const query = new URLSearchParams({ threadId })
   if (automationId) query.set('automationId', automationId)
-  const response = await fetch(`/codex-api/thread-automation?${query.toString()}`)
+  const response = await appFetch(`/codex-api/thread-automation?${query.toString()}`)
   const payload = await response.json().catch(() => null)
   if (!response.ok) {
     throw new Error(extractErrorMessage(payload, 'Failed to load thread automation'))
@@ -1204,7 +1205,7 @@ export async function upsertThreadAutomation(input: {
   rrule: string
   status: UiThreadAutomationStatus
 }): Promise<UiThreadAutomation> {
-  const response = await fetch('/codex-api/thread-automation', {
+  const response = await appFetch('/codex-api/thread-automation', {
     method: 'PUT',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(input),
@@ -1226,7 +1227,7 @@ export async function upsertProjectAutomation(input: {
   rrule: string
   status: UiThreadAutomationStatus
 }): Promise<UiThreadAutomation> {
-  const response = await fetch('/codex-api/project-automation', {
+  const response = await appFetch('/codex-api/project-automation', {
     method: 'PUT',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(input),
@@ -1243,7 +1244,7 @@ export async function upsertProjectAutomation(input: {
 export async function deleteThreadAutomation(threadId: string, automationId?: string): Promise<void> {
   const query = new URLSearchParams({ threadId })
   if (automationId) query.set('automationId', automationId)
-  const response = await fetch(`/codex-api/thread-automation?${query.toString()}`, {
+  const response = await appFetch(`/codex-api/thread-automation?${query.toString()}`, {
     method: 'DELETE',
   })
   const payload = await response.json().catch(() => null)
@@ -1255,7 +1256,7 @@ export async function deleteThreadAutomation(threadId: string, automationId?: st
 export async function deleteProjectAutomation(projectName: string, automationId?: string): Promise<void> {
   const query = new URLSearchParams({ projectName })
   if (automationId) query.set('automationId', automationId)
-  const response = await fetch(`/codex-api/project-automation?${query.toString()}`, {
+  const response = await appFetch(`/codex-api/project-automation?${query.toString()}`, {
     method: 'DELETE',
   })
   const payload = await response.json().catch(() => null)
@@ -1265,7 +1266,7 @@ export async function deleteProjectAutomation(projectName: string, automationId?
 }
 
 export async function runThreadAutomationNow(threadId: string, automationId: string): Promise<void> {
-  const response = await fetch('/codex-api/thread-automation/run', {
+  const response = await appFetch('/codex-api/thread-automation/run', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ threadId, automationId }),
@@ -1301,7 +1302,7 @@ function normalizeThreadTerminalSession(value: unknown): ThreadTerminalSession |
 }
 
 async function fetchTerminalJson(path: string, init?: RequestInit): Promise<unknown> {
-  const response = await fetch(path, init)
+  const response = await appFetch(path, init)
   const payload = await response.json().catch(() => null)
   if (!response.ok) {
     throw new Error(extractErrorMessage(payload, `Terminal request failed with HTTP ${response.status}`))
@@ -1412,7 +1413,7 @@ function normalizeAccountsListResult(payload: unknown): AccountsListResult {
 }
 
 export async function getAccounts(): Promise<AccountsListResult> {
-  const response = await fetch('/codex-api/accounts')
+  const response = await appFetch('/codex-api/accounts')
   const payload = (await response.json()) as unknown
   if (!response.ok) {
     throw new Error(getErrorMessageFromPayload(payload, 'Failed to load accounts'))
@@ -1422,7 +1423,7 @@ export async function getAccounts(): Promise<AccountsListResult> {
 }
 
 export async function refreshAccountsFromAuth(): Promise<AccountsListResult> {
-  const response = await fetch('/codex-api/accounts/refresh', {
+  const response = await appFetch('/codex-api/accounts/refresh', {
     method: 'POST',
   })
   const payload = (await response.json()) as unknown
@@ -1434,7 +1435,7 @@ export async function refreshAccountsFromAuth(): Promise<AccountsListResult> {
 }
 
 export async function startCodexLogin(): Promise<string> {
-  const response = await fetch('/codex-api/accounts/login/start', {
+  const response = await appFetch('/codex-api/accounts/login/start', {
     method: 'POST',
   })
   const payload = (await response.json()) as unknown
@@ -1451,7 +1452,7 @@ export async function startCodexLogin(): Promise<string> {
 }
 
 export async function completeCodexLogin(callbackUrl: string): Promise<AccountsListResult> {
-  const response = await fetch('/codex-api/accounts/login/complete', {
+  const response = await appFetch('/codex-api/accounts/login/complete', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ callbackUrl }),
@@ -1465,7 +1466,7 @@ export async function completeCodexLogin(callbackUrl: string): Promise<AccountsL
 }
 
 export async function switchAccount(storageId: string): Promise<UiAccountEntry> {
-  const response = await fetch('/codex-api/accounts/switch', {
+  const response = await appFetch('/codex-api/accounts/switch', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ storageId }),
@@ -1484,7 +1485,7 @@ export async function switchAccount(storageId: string): Promise<UiAccountEntry> 
 }
 
 export async function removeAccount(storageId: string): Promise<AccountsListResult> {
-  const response = await fetch('/codex-api/accounts/remove', {
+  const response = await appFetch('/codex-api/accounts/remove', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ storageId }),
@@ -1568,7 +1569,7 @@ export async function updateThreadFileChanges(
   scope?: 'single_turn' | 'turn_and_later',
 ): Promise<{ changed: number; errors: string[]; message?: string; revertedPatchIds?: string[]; appliedPatchIds?: string[] }> {
   try {
-    const response = await fetch('/codex-api/thread/rollback-files', {
+    const response = await appFetch('/codex-api/thread/rollback-files', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ threadId, turnId, cwd, action, patchIds, scope }),
@@ -1755,7 +1756,7 @@ function extractLocalImagePathFromUrl(value: string): string | null {
   if (!value) return null
   try {
     const parsed = new URL(value, 'http://localhost')
-    if (parsed.pathname !== '/codex-local-image') return null
+    if (stripAppBasePath(parsed.pathname) !== '/codex-local-image') return null
     const path = parsed.searchParams.get('path')?.trim() ?? ''
     return path.length > 0 ? path : null
   } catch {
@@ -1965,12 +1966,12 @@ export interface FreeModeStatus {
 }
 
 export async function getFreeModeStatus(): Promise<FreeModeStatus> {
-  const response = await fetch('/codex-api/free-mode/status')
+  const response = await appFetch('/codex-api/free-mode/status')
   return await response.json() as FreeModeStatus
 }
 
 export async function setFreeMode(enable: boolean): Promise<{ ok: boolean; enabled: boolean; model?: string; models?: string[] }> {
-  const response = await fetch('/codex-api/free-mode', {
+  const response = await appFetch('/codex-api/free-mode', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ enable }),
@@ -1979,7 +1980,7 @@ export async function setFreeMode(enable: boolean): Promise<{ ok: boolean; enabl
 }
 
 export async function setFreeModeCustomKey(key: string): Promise<{ ok: boolean; customKey: boolean }> {
-  const response = await fetch('/codex-api/free-mode/custom-key', {
+  const response = await appFetch('/codex-api/free-mode/custom-key', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ key }),
@@ -1992,7 +1993,7 @@ export async function setCustomProvider(
   apiKey: string,
   options?: { wireApi?: 'responses' | 'chat'; provider?: 'custom' | 'opencode-zen' | 'openrouter' },
 ): Promise<{ ok: boolean }> {
-  const response = await fetch('/codex-api/free-mode/custom-provider', {
+  const response = await appFetch('/codex-api/free-mode/custom-provider', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
@@ -2011,7 +2012,7 @@ async function fetchProviderModelIds(providerId?: string): Promise<{ ids: string
     const url = normalizedProviderId
       ? `/codex-api/provider-models?provider=${encodeURIComponent(normalizedProviderId)}`
       : '/codex-api/provider-models'
-    const response = await fetch(url, {
+    const response = await appFetch(url, {
       signal: AbortSignal.timeout(PROVIDER_MODELS_FETCH_TIMEOUT_MS),
     })
     let providerPayload: ProviderModelsResponse | null = null
@@ -2358,7 +2359,7 @@ export async function startDirectoryMcpLogin(name: string): Promise<DirectoryMcp
 }
 
 export async function getDirectoryComposioStatus(): Promise<DirectoryComposioStatus> {
-  const response = await fetch('/codex-api/composio/status')
+  const response = await appFetch('/codex-api/composio/status')
   if (!response.ok) {
     throw new Error(`Failed to load Composio status (${response.status})`)
   }
@@ -2375,7 +2376,7 @@ export async function listDirectoryComposioConnectors(
   if (cursor) params.set('cursor', cursor)
   if (limit && Number.isFinite(limit)) params.set('limit', String(Math.max(1, Math.floor(limit))))
   const suffix = params.toString()
-  const response = await fetch(`/codex-api/composio/connectors${suffix ? `?${suffix}` : ''}`)
+  const response = await appFetch(`/codex-api/composio/connectors${suffix ? `?${suffix}` : ''}`)
   if (!response.ok) {
     throw new Error(`Failed to list Composio connectors (${response.status})`)
   }
@@ -2388,7 +2389,7 @@ export async function listDirectoryComposioConnectors(
 }
 
 export async function readDirectoryComposioConnector(slug: string): Promise<DirectoryComposioConnectorDetail> {
-  const response = await fetch(`/codex-api/composio/connector?slug=${encodeURIComponent(slug)}`)
+  const response = await appFetch(`/codex-api/composio/connector?slug=${encodeURIComponent(slug)}`)
   if (!response.ok) {
     throw new Error(`Failed to load Composio connector (${response.status})`)
   }
@@ -2396,7 +2397,7 @@ export async function readDirectoryComposioConnector(slug: string): Promise<Dire
 }
 
 export async function startDirectoryComposioLogin(slug: string): Promise<DirectoryComposioLinkResult> {
-  const response = await fetch('/codex-api/composio/link', {
+  const response = await appFetch('/codex-api/composio/link', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ slug }),
@@ -2408,7 +2409,7 @@ export async function startDirectoryComposioLogin(slug: string): Promise<Directo
 }
 
 export async function startDirectoryComposioCliLogin(): Promise<DirectoryComposioLoginResult> {
-  const response = await fetch('/codex-api/composio/login', {
+  const response = await appFetch('/codex-api/composio/login', {
     method: 'POST',
   })
   if (!response.ok) {
@@ -2418,7 +2419,7 @@ export async function startDirectoryComposioCliLogin(): Promise<DirectoryComposi
 }
 
 export async function installDirectoryComposioCli(): Promise<DirectoryComposioInstallResult> {
-  const response = await fetch('/codex-api/composio/install', {
+  const response = await appFetch('/codex-api/composio/install', {
     method: 'POST',
   })
   if (!response.ok) {
@@ -2596,7 +2597,7 @@ export async function getWorkspaceRootsState(): Promise<WorkspaceRootsState> {
 }
 
 async function fetchWorkspaceRootsState(): Promise<WorkspaceRootsState> {
-  const response = await fetch('/codex-api/workspace-roots-state')
+  const response = await appFetch('/codex-api/workspace-roots-state')
   const payload = (await response.json()) as unknown
   if (!response.ok) {
     throw new Error('Failed to load workspace roots state')
@@ -2623,7 +2624,7 @@ function invalidateWorkspaceRootsStateCache(): void {
 }
 
 export async function getThreadQueueState(): Promise<ThreadQueueState> {
-  const response = await fetch('/codex-api/thread-queue-state')
+  const response = await appFetch('/codex-api/thread-queue-state')
   const payload = (await response.json()) as unknown
   if (!response.ok) {
     throw new Error('Failed to load thread queue state')
@@ -2636,7 +2637,7 @@ export async function getThreadQueueState(): Promise<ThreadQueueState> {
 }
 
 export async function setThreadQueueState(nextState: ThreadQueueState): Promise<void> {
-  const response = await fetch('/codex-api/thread-queue-state', {
+  const response = await appFetch('/codex-api/thread-queue-state', {
     method: 'PUT',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(normalizeThreadQueueState(nextState)),
@@ -2648,7 +2649,7 @@ export async function setThreadQueueState(nextState: ThreadQueueState): Promise<
 
 export async function createWorktree(sourceCwd: string, baseBranch?: string): Promise<WorktreeCreateResult> {
   const normalizedBaseBranch = (baseBranch ?? '').trim()
-  const response = await fetch('/codex-api/worktree/create', {
+  const response = await appFetch('/codex-api/worktree/create', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
@@ -2668,7 +2669,7 @@ export async function createWorktree(sourceCwd: string, baseBranch?: string): Pr
 }
 
 export async function createPermanentWorktree(sourceCwd: string, worktreeName: string): Promise<WorktreeCreateResult> {
-  const response = await fetch('/codex-api/worktree/create-permanent', {
+  const response = await appFetch('/codex-api/worktree/create-permanent', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
@@ -2691,7 +2692,7 @@ export async function getWorktreeBranchOptions(sourceCwd: string): Promise<Workt
   const normalizedSourceCwd = sourceCwd.trim()
   if (!normalizedSourceCwd) return []
   const query = new URLSearchParams({ sourceCwd: normalizedSourceCwd })
-  const response = await fetch(`/codex-api/worktree/branches?${query.toString()}`)
+  const response = await appFetch(`/codex-api/worktree/branches?${query.toString()}`)
   const payload = (await response.json()) as { data?: unknown; error?: string }
   if (!response.ok) {
     throw new Error(payload.error || 'Failed to load branches')
@@ -2720,7 +2721,7 @@ export async function getGitBranchState(cwd: string): Promise<GitBranchState> {
     return { currentBranch: null, headSha: null, headSubject: null, headDate: null, detached: false, dirty: false, gitRoot: '', options: [] }
   }
   const query = new URLSearchParams({ cwd: normalizedCwd })
-  const response = await fetch(`/codex-api/git/branches?${query.toString()}`)
+  const response = await appFetch(`/codex-api/git/branches?${query.toString()}`)
   const payload = (await response.json()) as { data?: unknown; error?: string }
   if (!response.ok) {
     throw new Error(payload.error || 'Failed to load Git branch state')
@@ -2774,7 +2775,7 @@ export async function getGitRepositoryStatus(cwd: string): Promise<GitRepository
     return { isGitRepo: false, gitRoot: '' }
   }
   const query = new URLSearchParams({ cwd: normalizedCwd })
-  const response = await fetch(`/codex-api/git/repository-status?${query.toString()}`)
+  const response = await appFetch(`/codex-api/git/repository-status?${query.toString()}`)
   const payload = (await response.json()) as { data?: unknown; error?: string }
   if (!response.ok) {
     throw new Error(payload.error || 'Failed to read Git repository status')
@@ -2789,7 +2790,7 @@ export async function getGitRepositoryStatus(cwd: string): Promise<GitRepository
 }
 
 export async function checkoutGitBranch(cwd: string, branch: string): Promise<string | null> {
-  const response = await fetch('/codex-api/git/checkout', {
+  const response = await appFetch('/codex-api/git/checkout', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
@@ -2814,7 +2815,7 @@ export async function getGitBranchCommits(cwd: string, branch: string, options: 
     branch: normalizedBranch,
     includeResetHistory: options.includeResetHistory === false ? 'false' : 'true',
   })
-  const response = await fetch(`/codex-api/git/branch-commits?${query.toString()}`)
+  const response = await appFetch(`/codex-api/git/branch-commits?${query.toString()}`)
   const payload = (await response.json()) as { data?: unknown; error?: string }
   if (!response.ok) {
     throw new Error(payload.error || 'Failed to load branch commits')
@@ -2840,7 +2841,7 @@ export async function getGitCommitFiles(cwd: string, sha: string): Promise<GitCo
     cwd: normalizedCwd,
     sha: normalizedSha,
   })
-  const response = await fetch(`/codex-api/git/commit-files?${query.toString()}`)
+  const response = await appFetch(`/codex-api/git/commit-files?${query.toString()}`)
   const payload = (await response.json()) as { data?: unknown; error?: string }
   if (!response.ok) {
     throw new Error(payload.error || 'Failed to load commit files')
@@ -2861,7 +2862,7 @@ export async function getGitCommitFiles(cwd: string, sha: string): Promise<GitCo
 }
 
 export async function resetGitBranchToCommit(cwd: string, branch: string, sha: string): Promise<GitBranchState> {
-  const response = await fetch('/codex-api/git/reset-to-commit', {
+  const response = await appFetch('/codex-api/git/reset-to-commit', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
@@ -2903,7 +2904,7 @@ export async function getReviewSnapshot(
   if (commitSha && commitSha.trim()) {
     query.set('commitSha', commitSha.trim())
   }
-  const response = await fetch(`/codex-api/review/snapshot?${query.toString()}`)
+  const response = await appFetch(`/codex-api/review/snapshot?${query.toString()}`)
   const payload = (await response.json()) as unknown
   if (!response.ok) {
     throw new Error(getErrorMessageFromPayload(payload, 'Failed to load review snapshot'))
@@ -2916,7 +2917,7 @@ export async function getReviewSummary(
   workspaceView: UiReviewWorkspaceView,
 ): Promise<UiReviewSummary> {
   const query = new URLSearchParams({ cwd, workspaceView })
-  const response = await fetch(`/codex-api/review/summary?${query.toString()}`)
+  const response = await appFetch(`/codex-api/review/summary?${query.toString()}`)
   const payload = (await response.json()) as unknown
   if (!response.ok) {
     throw new Error(getErrorMessageFromPayload(payload, 'Failed to load review summary'))
@@ -2934,7 +2935,7 @@ export async function applyReviewAction(payload: {
   previousPath?: string | null
   patch?: string
 }): Promise<UiReviewSnapshot> {
-  const response = await fetch('/codex-api/review/action', {
+  const response = await appFetch('/codex-api/review/action', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(payload),
@@ -2947,7 +2948,7 @@ export async function applyReviewAction(payload: {
 }
 
 export async function initializeReviewGit(cwd: string): Promise<void> {
-  const response = await fetch('/codex-api/review/git/init', {
+  const response = await appFetch('/codex-api/review/git/init', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ cwd }),
@@ -2978,7 +2979,7 @@ export async function startThreadReview(
 }
 
 export async function getHomeDirectory(): Promise<string> {
-  const response = await fetch('/codex-api/home-directory')
+  const response = await appFetch('/codex-api/home-directory')
   const payload = (await response.json()) as unknown
   if (!response.ok) {
     throw new Error('Failed to load home directory')
@@ -2999,7 +3000,7 @@ export async function listLocalDirectories(path: string, options?: { showHidden?
   if (options?.showHidden === true) {
     query.set('showHidden', '1')
   }
-  const response = await fetch(`/codex-local-directories?${query.toString()}`)
+  const response = await appFetch(`/codex-local-directories?${query.toString()}`)
   const payload = await readJsonResponse(response)
   if (!response.ok) {
     const message = getErrorMessageFromPayload(payload, 'Failed to load local directories')
@@ -3040,7 +3041,7 @@ async function readJsonResponse(response: Response): Promise<unknown> {
 }
 
 export async function setWorkspaceRootsState(nextState: WorkspaceRootsState): Promise<void> {
-  const response = await fetch('/codex-api/workspace-roots-state', {
+  const response = await appFetch('/codex-api/workspace-roots-state', {
     method: 'PUT',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(nextState),
@@ -3052,7 +3053,7 @@ export async function setWorkspaceRootsState(nextState: WorkspaceRootsState): Pr
 }
 
 export async function openProjectRoot(path: string, options?: { createIfMissing?: boolean; label?: string }): Promise<string> {
-  const response = await fetch('/codex-api/project-root', {
+  const response = await appFetch('/codex-api/project-root', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
@@ -3081,7 +3082,7 @@ export async function openProjectRoot(path: string, options?: { createIfMissing?
 
 export function getProjectZipDownloadUrl(cwd: string): string {
   const query = new URLSearchParams({ cwd })
-  return `/codex-api/project-zip?${query.toString()}`
+  return appPath(`/codex-api/project-zip?${query.toString()}`)
 }
 
 function readDownloadFileName(response: Response, fallback: string): string {
@@ -3102,7 +3103,7 @@ export async function downloadProjectZip(
   cwd: string,
   onProgress?: (progress: { loaded: number; total: number | null }) => void,
 ): Promise<{ blob: Blob; fileName: string }> {
-  const response = await fetch(getProjectZipDownloadUrl(cwd))
+  const response = await appFetch(getProjectZipDownloadUrl(cwd))
   if (!response.ok) {
     const payload = await response.json().catch(() => null)
     const fallback = 'Failed to export project'
@@ -3146,7 +3147,7 @@ export async function downloadProjectZip(
 
 export async function importProjectZip(file: Blob, parent: string): Promise<{ path: string; importedSessions: number }> {
   const query = new URLSearchParams({ parent })
-  const response = await fetch(`/codex-api/project-import?${query.toString()}`, {
+  const response = await appFetch(`/codex-api/project-import?${query.toString()}`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/zip' },
     body: file,
@@ -3175,7 +3176,7 @@ export async function importProjectZip(file: Blob, parent: string): Promise<{ pa
 }
 
 export async function createLocalDirectory(path: string): Promise<string> {
-  const response = await fetch('/codex-api/local-directory', {
+  const response = await appFetch('/codex-api/local-directory', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ path }),
@@ -3201,7 +3202,7 @@ export async function createLocalDirectory(path: string): Promise<string> {
 }
 
 export async function cloneGithubRepository(url: string, basePath: string): Promise<string> {
-  const response = await fetch('/codex-api/github-clone', {
+  const response = await appFetch('/codex-api/github-clone', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ url, basePath }),
@@ -3223,7 +3224,7 @@ export async function cloneGithubRepository(url: string, basePath: string): Prom
 }
 
 export async function createProjectlessThreadDirectory(prompt?: string): Promise<{ cwd: string; outputDirectory: string; workspaceRoot: string }> {
-  const response = await fetch('/codex-api/projectless-thread-cwd', {
+  const response = await appFetch('/codex-api/projectless-thread-cwd', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ prompt: prompt ?? null }),
@@ -3254,7 +3255,7 @@ export async function createProjectlessThreadDirectory(prompt?: string): Promise
 
 export async function getProjectRootSuggestion(basePath: string): Promise<{ name: string; path: string }> {
   const query = new URLSearchParams({ basePath })
-  const response = await fetch(`/codex-api/project-root-suggestion?${query.toString()}`)
+  const response = await appFetch(`/codex-api/project-root-suggestion?${query.toString()}`)
   const payload = (await response.json()) as unknown
   if (!response.ok) {
     const message = getErrorMessageFromPayload(payload, 'Failed to suggest project name')
@@ -3277,7 +3278,7 @@ export async function getProjectRootSuggestion(basePath: string): Promise<{ name
 export async function searchComposerFiles(cwd: string, query: string, limit = 20): Promise<ComposerFileSuggestion[]> {
   const trimmedCwd = cwd.trim()
   if (!trimmedCwd) return []
-  const response = await fetch('/codex-api/composer-file-search', {
+  const response = await appFetch('/codex-api/composer-file-search', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
@@ -3312,7 +3313,7 @@ export async function searchThreads(
   query: string,
   limit = 200,
 ): Promise<ThreadSearchResult> {
-  const response = await fetch('/codex-api/thread-search', {
+  const response = await appFetch('/codex-api/thread-search', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ query, limit }),
@@ -3328,7 +3329,7 @@ export async function configureTelegramBot(
   botToken: string,
   allowedUserIds: Array<number | '*'>,
 ): Promise<void> {
-  const response = await fetch('/codex-api/telegram/configure-bot', {
+  const response = await appFetch('/codex-api/telegram/configure-bot', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
@@ -3344,7 +3345,7 @@ export async function configureTelegramBot(
 }
 
 export async function getTelegramConfig(): Promise<TelegramConfig> {
-  const response = await fetch('/codex-api/telegram/config')
+  const response = await appFetch('/codex-api/telegram/config')
   const payload = await response.json()
   if (!response.ok) {
     const message = getErrorMessageFromPayload(payload, 'Failed to load Telegram configuration')
@@ -3376,7 +3377,7 @@ export async function getTelegramConfig(): Promise<TelegramConfig> {
 }
 
 export async function getTelegramStatus(): Promise<TelegramStatus> {
-  const response = await fetch('/codex-api/telegram/status')
+  const response = await appFetch('/codex-api/telegram/status')
   const payload = await response.json()
   if (!response.ok) {
     const message = getErrorMessageFromPayload(payload, 'Failed to load Telegram status')
@@ -3419,7 +3420,7 @@ export type FirstLaunchPluginsCardPreference = { dismissed: boolean }
 
 export async function getThreadTitleCache(): Promise<ThreadTitleCache> {
   try {
-    const response = await fetch('/codex-api/thread-titles')
+    const response = await appFetch('/codex-api/thread-titles')
     if (!response.ok) return { titles: {}, order: [] }
     const envelope = (await response.json()) as { data?: ThreadTitleCache }
     return envelope.data ?? { titles: {}, order: [] }
@@ -3430,7 +3431,7 @@ export async function getThreadTitleCache(): Promise<ThreadTitleCache> {
 
 export async function persistThreadTitle(id: string, title: string): Promise<void> {
   try {
-    await fetch('/codex-api/thread-titles', {
+    await appFetch('/codex-api/thread-titles', {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ id, title }),
@@ -3442,7 +3443,7 @@ export async function persistThreadTitle(id: string, title: string): Promise<voi
 
 export async function getPinnedThreadState(): Promise<ThreadPinnedState> {
   try {
-    const response = await fetch('/codex-api/thread-pins')
+    const response = await appFetch('/codex-api/thread-pins')
     if (!response.ok) return { threadIds: [] }
     const envelope = (await response.json()) as { data?: ThreadPinnedState }
     return envelope.data ?? { threadIds: [] }
@@ -3453,7 +3454,7 @@ export async function getPinnedThreadState(): Promise<ThreadPinnedState> {
 
 export async function persistPinnedThreadIds(threadIds: string[]): Promise<void> {
   try {
-    await fetch('/codex-api/thread-pins', {
+    await appFetch('/codex-api/thread-pins', {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ threadIds }),
@@ -3465,7 +3466,7 @@ export async function persistPinnedThreadIds(threadIds: string[]): Promise<void>
 
 export async function getFirstLaunchPluginsCardPreference(): Promise<FirstLaunchPluginsCardPreference> {
   try {
-    const response = await fetch('/codex-api/preferences/first-launch-plugins-card')
+    const response = await appFetch('/codex-api/preferences/first-launch-plugins-card')
     if (!response.ok) return { dismissed: false }
     const envelope = (await response.json()) as { data?: FirstLaunchPluginsCardPreference }
     return { dismissed: envelope.data?.dismissed === true }
@@ -3476,7 +3477,7 @@ export async function getFirstLaunchPluginsCardPreference(): Promise<FirstLaunch
 
 export async function persistFirstLaunchPluginsCardPreference(dismissed: boolean): Promise<void> {
   try {
-    await fetch('/codex-api/preferences/first-launch-plugins-card', {
+    await appFetch('/codex-api/preferences/first-launch-plugins-card', {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ dismissed }),
@@ -3601,7 +3602,7 @@ export async function getSkillsList(cwds?: string[]): Promise<SkillInfo[]> {
 
 export async function getComposerPrompts(): Promise<ComposerPromptInfo[]> {
   try {
-    const response = await fetch('/codex-api/prompts')
+    const response = await appFetch('/codex-api/prompts')
     if (!response.ok) return []
     const payload = (await response.json()) as { data?: ComposerPromptInfo[] }
     return Array.isArray(payload.data) ? payload.data : []
@@ -3612,7 +3613,7 @@ export async function getComposerPrompts(): Promise<ComposerPromptInfo[]> {
 
 export async function createComposerPrompt(name: string, content: string): Promise<ComposerPromptInfo | null> {
   try {
-    const response = await fetch('/codex-api/prompts', {
+    const response = await appFetch('/codex-api/prompts', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ name, content }),
@@ -3628,7 +3629,7 @@ export async function createComposerPrompt(name: string, content: string): Promi
 export async function removeComposerPrompt(path: string): Promise<boolean> {
   try {
     const params = new URLSearchParams({ path })
-    const response = await fetch(`/codex-api/prompts?${params.toString()}`, {
+    const response = await appFetch(`/codex-api/prompts?${params.toString()}`, {
       method: 'DELETE',
     })
     return response.ok
@@ -3645,7 +3646,7 @@ export async function uploadFile(file: File): Promise<string | null> {
   try {
     const form = new FormData()
     form.append('file', file)
-    const resp = await fetch('/codex-api/upload-file', {
+    const resp = await appFetch('/codex-api/upload-file', {
       method: 'POST',
       body: form,
       signal: controller.signal,

--- a/src/api/codexRpcClient.ts
+++ b/src/api/codexRpcClient.ts
@@ -1,5 +1,6 @@
 import type { RpcEnvelope, RpcMethodCatalog } from '../types/codex'
 import { CodexApiError, extractErrorMessage } from './codexErrors'
+import { appFetch, appPath, appWebSocketUrl } from '../basePath'
 
 type RpcRequestBody = {
   method: string
@@ -32,7 +33,7 @@ export async function rpcCall<T>(method: string, params?: unknown): Promise<T> {
 
   let response: Response
   try {
-    response = await fetch('/codex-api/rpc', {
+    response = await appFetch('/codex-api/rpc', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -80,7 +81,7 @@ export async function rpcCall<T>(method: string, params?: unknown): Promise<T> {
 }
 
 export async function fetchRpcMethodCatalog(): Promise<string[]> {
-  const response = await fetch('/codex-api/meta/methods')
+  const response = await appFetch('/codex-api/meta/methods')
 
   let payload: unknown = null
   try {
@@ -105,7 +106,7 @@ export async function fetchRpcMethodCatalog(): Promise<string[]> {
 }
 
 export async function fetchRpcNotificationCatalog(): Promise<string[]> {
-  const response = await fetch('/codex-api/meta/notifications')
+  const response = await appFetch('/codex-api/meta/notifications')
 
   let payload: unknown = null
   try {
@@ -191,7 +192,7 @@ export function subscribeRpcNotifications(onNotification: (value: RpcNotificatio
   const attachSse = (attempt = 0) => {
     if (typeof EventSource === 'undefined' || closed) return
     cleanup?.()
-    const source = new EventSource('/codex-api/events')
+    const source = new EventSource(appPath('/codex-api/events'))
     let isConnectionClosed = false
 
     source.onmessage = (event) => {
@@ -233,8 +234,7 @@ export function subscribeRpcNotifications(onNotification: (value: RpcNotificatio
     }
 
     cleanup?.()
-    const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
-    const socket = new WebSocket(`${protocol}//${window.location.host}/codex-api/ws`)
+    const socket = new WebSocket(appWebSocketUrl('/codex-api/ws'))
     let didOpen = false
     let intentionallyClosed = false
     let fallbackTimer: number | null = window.setTimeout(() => {
@@ -306,7 +306,7 @@ export function subscribeRpcNotifications(onNotification: (value: RpcNotificatio
 export async function respondServerRequest(body: ServerRequestReplyBody): Promise<void> {
   let response: Response
   try {
-    response = await fetch('/codex-api/server-requests/respond', {
+    response = await appFetch('/codex-api/server-requests/respond', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -340,7 +340,7 @@ export async function respondServerRequest(body: ServerRequestReplyBody): Promis
 }
 
 export async function fetchPendingServerRequests(): Promise<unknown[]> {
-  const response = await fetch('/codex-api/server-requests/pending')
+  const response = await appFetch('/codex-api/server-requests/pending')
 
   let payload: unknown = null
   try {

--- a/src/api/normalizers/v2.ts
+++ b/src/api/normalizers/v2.ts
@@ -6,6 +6,7 @@ import type {
   Turn,
   UserInput,
 } from '../appServerDtos'
+import { appPath, stripAppBasePath } from '../../basePath'
 import type {
   CommandExecutionData,
   UiFileAttachment,
@@ -74,7 +75,7 @@ function extractCodexUserRequestText(value: string): string {
 }
 
 function toLocalImageUrl(path: string): string {
-  return `/codex-local-image?path=${encodeURIComponent(path)}`
+  return appPath(`/codex-local-image?path=${encodeURIComponent(path)}`)
 }
 
 function toImageGenerationUrl(value: string): string {
@@ -84,7 +85,7 @@ function toImageGenerationUrl(value: string): string {
     trimmed.startsWith('data:') ||
     trimmed.startsWith('http://') ||
     trimmed.startsWith('https://') ||
-    trimmed.startsWith('/codex-local-image?')
+    stripAppBasePath(trimmed).startsWith('/codex-local-image?')
   ) {
     return trimmed
   }

--- a/src/basePath.test.ts
+++ b/src/basePath.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { appPath, normalizeBasePath, stripAppBasePath } from './basePath'
+import { appPath, getAppBasePath, normalizeBasePath, stripAppBasePath } from './basePath'
 
 describe('configurable base path', () => {
   it('normalizes optional leading and trailing slashes', () => {
@@ -15,6 +15,13 @@ describe('configurable base path', () => {
   it('strips the configured prefix when inspecting application URLs', () => {
     expect(stripAppBasePath('/codex/workspace-1/codex-local-image?path=x', '/codex/workspace-1'))
       .toBe('/codex-local-image?path=x')
+  })
+
+  it('resolves the ambient prefix once and reuses it for default arguments', () => {
+    const first = getAppBasePath()
+    expect(getAppBasePath()).toBe(first)
+    expect(appPath('/codex-api/rpc')).toBe(appPath('/codex-api/rpc', first))
+    expect(stripAppBasePath('/codex-api/rpc')).toBe(stripAppBasePath('/codex-api/rpc', first))
   })
 
   it('rejects traversal and non-path delimiters', () => {

--- a/src/basePath.test.ts
+++ b/src/basePath.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+import { appPath, normalizeBasePath, stripAppBasePath } from './basePath'
+
+describe('configurable base path', () => {
+  it('normalizes optional leading and trailing slashes', () => {
+    expect(normalizeBasePath('codex/workspace-1/')).toBe('/codex/workspace-1')
+    expect(normalizeBasePath('/')).toBe('')
+  })
+
+  it('prefixes application routes exactly once', () => {
+    expect(appPath('/codex-api/rpc', '/codex/workspace-1')).toBe('/codex/workspace-1/codex-api/rpc')
+    expect(appPath('/codex/workspace-1/codex-api/rpc', '/codex/workspace-1')).toBe('/codex/workspace-1/codex-api/rpc')
+  })
+
+  it('strips the configured prefix when inspecting application URLs', () => {
+    expect(stripAppBasePath('/codex/workspace-1/codex-local-image?path=x', '/codex/workspace-1'))
+      .toBe('/codex-local-image?path=x')
+  })
+
+  it('rejects traversal and non-path delimiters', () => {
+    expect(() => normalizeBasePath('/codex/../other')).toThrow()
+    expect(() => normalizeBasePath('/codex/workspace?active=1')).toThrow()
+  })
+})

--- a/src/basePath.ts
+++ b/src/basePath.ts
@@ -8,12 +8,12 @@ export function normalizeBasePath(value: string | undefined | null): string {
   const trimmed = value?.trim() ?? ''
   if (!trimmed || trimmed === '/') return ''
   if (trimmed.includes('?') || trimmed.includes('#') || trimmed.includes('\\') || /[\s"'<>]/u.test(trimmed)) {
-    throw new Error('CODEXUI_BASE_PATH must contain only URL path segments')
+    throw new Error('Base path must contain only URL path segments')
   }
 
   const normalized = `/${trimmed.replace(/^\/+|\/+$/gu, '')}`.replace(/\/{2,}/gu, '/')
   if (normalized.split('/').some((segment) => segment === '.' || segment === '..')) {
-    throw new Error('CODEXUI_BASE_PATH cannot contain . or .. segments')
+    throw new Error('Base path cannot contain . or .. segments')
   }
   return normalized
 }

--- a/src/basePath.ts
+++ b/src/basePath.ts
@@ -1,0 +1,52 @@
+function readInjectedBasePath(): string {
+  if (typeof document === 'undefined') return ''
+  const value = document.querySelector<HTMLMetaElement>('meta[name="codexui-base-path"]')?.content ?? ''
+  return value === '__CODEXUI_BASE_PATH__' ? '' : value
+}
+
+export function normalizeBasePath(value: string | undefined | null): string {
+  const trimmed = value?.trim() ?? ''
+  if (!trimmed || trimmed === '/') return ''
+  if (trimmed.includes('?') || trimmed.includes('#') || trimmed.includes('\\') || /[\s"'<>]/u.test(trimmed)) {
+    throw new Error('CODEXUI_BASE_PATH must contain only URL path segments')
+  }
+
+  const normalized = `/${trimmed.replace(/^\/+|\/+$/gu, '')}`.replace(/\/{2,}/gu, '/')
+  if (normalized.split('/').some((segment) => segment === '.' || segment === '..')) {
+    throw new Error('CODEXUI_BASE_PATH cannot contain . or .. segments')
+  }
+  return normalized
+}
+
+export function getAppBasePath(): string {
+  const injected = readInjectedBasePath()
+  if (injected) return normalizeBasePath(injected)
+
+  const viteBasePath = typeof import.meta.env.VITE_CODEXUI_BASE_PATH === 'string'
+    ? import.meta.env.VITE_CODEXUI_BASE_PATH
+    : ''
+  return normalizeBasePath(viteBasePath)
+}
+
+export function appPath(path: string, basePath = getAppBasePath()): string {
+  if (!path.startsWith('/')) return path
+  const normalizedBasePath = normalizeBasePath(basePath)
+  if (!normalizedBasePath || path === normalizedBasePath || path.startsWith(`${normalizedBasePath}/`)) return path
+  return `${normalizedBasePath}${path}`
+}
+
+export function stripAppBasePath(path: string, basePath = getAppBasePath()): string {
+  const normalizedBasePath = normalizeBasePath(basePath)
+  if (!normalizedBasePath) return path
+  if (path === normalizedBasePath) return '/'
+  return path.startsWith(`${normalizedBasePath}/`) ? path.slice(normalizedBasePath.length) : path
+}
+
+export function appFetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
+  return fetch(typeof input === 'string' ? appPath(input) : input, init)
+}
+
+export function appWebSocketUrl(path: string): string {
+  const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
+  return `${protocol}//${window.location.host}${appPath(path)}`
+}

--- a/src/basePath.ts
+++ b/src/basePath.ts
@@ -18,7 +18,9 @@ export function normalizeBasePath(value: string | undefined | null): string {
   return normalized
 }
 
-export function getAppBasePath(): string {
+let cachedAppBasePath: string | null = null
+
+function resolveAppBasePath(): string {
   const injected = readInjectedBasePath()
   if (injected) return normalizeBasePath(injected)
 
@@ -28,15 +30,22 @@ export function getAppBasePath(): string {
   return normalizeBasePath(viteBasePath)
 }
 
-export function appPath(path: string, basePath = getAppBasePath()): string {
+// The prefix is injected into the document before any script runs and cannot change
+// afterwards, so resolve it once instead of querying the DOM for every URL.
+export function getAppBasePath(): string {
+  cachedAppBasePath ??= resolveAppBasePath()
+  return cachedAppBasePath
+}
+
+export function appPath(path: string, basePath?: string): string {
   if (!path.startsWith('/')) return path
-  const normalizedBasePath = normalizeBasePath(basePath)
+  const normalizedBasePath = basePath === undefined ? getAppBasePath() : normalizeBasePath(basePath)
   if (!normalizedBasePath || path === normalizedBasePath || path.startsWith(`${normalizedBasePath}/`)) return path
   return `${normalizedBasePath}${path}`
 }
 
-export function stripAppBasePath(path: string, basePath = getAppBasePath()): string {
-  const normalizedBasePath = normalizeBasePath(basePath)
+export function stripAppBasePath(path: string, basePath?: string): string {
+  const normalizedBasePath = basePath === undefined ? getAppBasePath() : normalizeBasePath(basePath)
   if (!normalizedBasePath) return path
   if (path === normalizedBasePath) return '/'
   return path.startsWith(`${normalizedBasePath}/`) ? path.slice(normalizedBasePath.length) : path

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -496,6 +496,7 @@ async function addProjectOnly(projectPath: string): Promise<void> {
 
 async function startServer(options: {
   port: string
+  basePath: string
   password: string | boolean
   tunnel: boolean
   open: boolean
@@ -530,12 +531,13 @@ async function startServer(options: {
     console.log('\nCodex is not logged in. You can log in later via settings or run `codexui login`.\n')
   }
   const requestedPort = parseInt(options.port, 10)
+  const basePath = normalizeBasePath(options.basePath)
   const passwordResolution = resolvePassword(options.password)
   const password = passwordResolution.password
   const generatedPasswordPath = password && passwordResolution.generated
     ? await persistGeneratedPassword(password)
     : null
-  const { app, dispose, attachWebSocket } = createApp({ password })
+  const { app, dispose, attachWebSocket } = createApp({ password, basePath })
   const server = createServer(app)
   attachWebSocket(server)
   const port = await listenWithFallback(server, requestedPort)
@@ -568,7 +570,6 @@ async function startServer(options: {
     `  Codex sandbox: ${runtimeConfig.sandboxMode}`,
     `  Approval policy: ${runtimeConfig.approvalPolicy}`,
   ]
-  const basePath = normalizeBasePath(process.env.CODEXUI_BASE_PATH)
   const accessUrls = getAccessibleUrls(port, basePath)
   if (accessUrls.length > 0) {
     lines.push(`  Local:    ${accessUrls[0]}`)
@@ -632,6 +633,7 @@ program
   .argument('[projectPath]', 'project directory to open on launch')
   .option('--open-project <path>', 'open project directory on launch (Codex desktop parity)')
   .option('-p, --port <port>', 'port to listen on', '5900')
+  .option('--base-path <path>', 'URL path prefix used when serving behind a reverse proxy', '')
   .option('--password <pass>', 'set a specific password')
   .option('--no-password', 'disable password protection')
   .option('--tunnel', 'start cloudflared tunnel (default is auto by Tailscale detection)', true)
@@ -648,6 +650,7 @@ program
     projectPath: string | undefined,
     opts: {
       port: string
+      basePath: string
       password: string | boolean
       tunnel: boolean
       open: boolean

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -25,6 +25,7 @@ import {
 import { createServer as createApp } from '../server/httpServer.js'
 import { generatePassword } from '../server/password.js'
 import { spawnSyncCommand } from '../utils/commandInvocation.js'
+import { normalizeBasePath } from '../basePath.js'
 
 const program = new Command().name('codexui').description('Web interface for Codex app-server')
 const __dirname = dirname(fileURLToPath(import.meta.url))
@@ -315,8 +316,8 @@ function parseCloudflaredUrl(chunk: string): string | null {
   return urlMatch[urlMatch.length - 1] ?? null
 }
 
-function getAccessibleUrls(port: number): string[] {
-  const urls = new Set<string>([`http://localhost:${String(port)}`])
+function getAccessibleUrls(port: number, basePath = ''): string[] {
+  const urls = new Set<string>([`http://localhost:${String(port)}${basePath}`])
   try {
     const interfaces = networkInterfaces()
     for (const entries of Object.values(interfaces)) {
@@ -328,7 +329,7 @@ function getAccessibleUrls(port: number): string[] {
           continue
         }
         if (entry.family === 'IPv4') {
-          urls.add(`http://${entry.address}:${String(port)}`)
+          urls.add(`http://${entry.address}:${String(port)}${basePath}`)
         }
       }
     }
@@ -567,7 +568,8 @@ async function startServer(options: {
     `  Codex sandbox: ${runtimeConfig.sandboxMode}`,
     `  Approval policy: ${runtimeConfig.approvalPolicy}`,
   ]
-  const accessUrls = getAccessibleUrls(port)
+  const basePath = normalizeBasePath(process.env.CODEXUI_BASE_PATH)
+  const accessUrls = getAccessibleUrls(port, basePath)
   if (accessUrls.length > 0) {
     lines.push(`  Local:    ${accessUrls[0]}`)
     for (const accessUrl of accessUrls.slice(1)) {
@@ -584,7 +586,7 @@ async function startServer(options: {
     lines.push('  Use that file to retrieve the password for untrusted origins.')
   }
 
-  const tunnelQrUrl = tunnelUrl ? buildTunnelAutologinUrl(tunnelUrl, password) : null
+  const tunnelQrUrl = tunnelUrl ? buildTunnelAutologinUrl(`${tunnelUrl}${basePath}`, password) : null
   if (tunnelUrl) {
     lines.push(`  Tunnel:   ${tunnelQrUrl ?? tunnelUrl}`)
     lines.push('  Tunnel QR code below')
@@ -597,7 +599,7 @@ async function startServer(options: {
     qrcode.generate(tunnelQrUrl, { small: true })
     console.log('')
   }
-  if (options.open) openBrowser(`http://localhost:${String(port)}`)
+  if (options.open) openBrowser(`http://localhost:${String(port)}${basePath || '/'}`)
 
   function shutdown() {
     console.log('\nShutting down...')

--- a/src/components/content/DirectoryHub.vue
+++ b/src/components/content/DirectoryHub.vue
@@ -690,6 +690,7 @@ import {
 } from '../../api/codexGateway'
 import { sortComposioConnectors, type DirectorySortMode } from './directoryHubUtils'
 import SkillsHub from './SkillsHub.vue'
+import { appPath } from '../../basePath'
 
 type DirectoryTab = 'plugins' | 'apps' | 'composio' | 'skills'
 const COMPOSIO_SKILL_PATH = '/Users/igor/.codex/skills/shared_skills/composio-cli/SKILL.md'
@@ -1169,10 +1170,10 @@ function showToast(text: string, type: 'success' | 'error' = 'success'): void {
 
 function localAssetSrc(path: string): string {
   if (!path) return ''
-  if (path.startsWith('connectors://')) return `/codex-api/connector-logo?src=${encodeURIComponent(path)}`
+  if (path.startsWith('connectors://')) return appPath(`/codex-api/connector-logo?src=${encodeURIComponent(path)}`)
   if (/^https?:\/\//i.test(path) || path.startsWith('data:')) return path
   if (!path.startsWith('/')) return ''
-  return `/codex-local-image?path=${encodeURIComponent(path)}`
+  return appPath(`/codex-local-image?path=${encodeURIComponent(path)}`)
 }
 
 function pluginIconSrc(plugin: DirectoryPluginSummary | null): string {

--- a/src/components/content/SkillCard.vue
+++ b/src/components/content/SkillCard.vue
@@ -46,6 +46,7 @@
 import { computed } from 'vue'
 import { useUiLanguage } from '../../composables/useUiLanguage'
 import IconTablerFolder from '../icons/IconTablerFolder.vue'
+import { appPath } from '../../basePath'
 
 const props = withDefaults(defineProps<{
   skill: {
@@ -86,7 +87,7 @@ const skillDirPath = computed(() => {
 function onBrowse(): void {
   const dir = skillDirPath.value
   if (!dir) return
-  window.open(`/codex-local-browse${encodeURI(dir)}`, '_blank', 'noopener,noreferrer')
+  window.open(appPath(`/codex-local-browse${encodeURI(dir)}`), '_blank', 'noopener,noreferrer')
 }
 
 const publishedLabel = computed(() => {

--- a/src/components/content/SkillDetailModal.vue
+++ b/src/components/content/SkillDetailModal.vue
@@ -92,6 +92,7 @@
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
 import { useUiLanguage } from '../../composables/useUiLanguage'
+import { appFetch, appPath } from '../../basePath'
 import IconTablerX from '../icons/IconTablerX.vue'
 
 export type HubSkill = {
@@ -173,7 +174,7 @@ async function fetchReadme(): Promise<void> {
     const params = new URLSearchParams({ owner: props.skill.owner, name: props.skill.name })
     if (props.skill.installed) params.set('installed', 'true')
     if (props.skill.path) params.set('path', props.skill.path)
-    const resp = await fetch(`/codex-api/skills-hub/readme?${params}`)
+    const resp = await appFetch(`/codex-api/skills-hub/readme?${params}`)
     if (!resp.ok) return
     const data = (await resp.json()) as { content?: string; description?: string }
     readmeContent.value = data.content ?? ''
@@ -216,7 +217,7 @@ function onTry(): void {
 function onBrowseFiles(): void {
   const dir = skillDirPath.value
   if (!dir) return
-  window.open(`/codex-local-browse${encodeURI(dir)}`, '_blank', 'noopener,noreferrer')
+  window.open(appPath(`/codex-local-browse${encodeURI(dir)}`), '_blank', 'noopener,noreferrer')
 }
 </script>
 

--- a/src/components/content/SkillsHub.vue
+++ b/src/components/content/SkillsHub.vue
@@ -152,6 +152,7 @@ import SkillDetailModal, { type HubSkill } from './SkillDetailModal.vue'
 import { useGithubSkillsSync } from '../../composables/useGithubSkillsSync'
 import { useFeedbackDiagnostics } from '../../composables/useFeedbackDiagnostics'
 import { useUiLanguage } from '../../composables/useUiLanguage'
+import { appFetch } from '../../basePath'
 
 const EMPTY_SKILL: HubSkill = { name: '', owner: '', description: '', url: '', installed: false }
 type SkillsHubPayload = { installed?: HubSkill[] }
@@ -250,7 +251,7 @@ async function fetchSkills(): Promise<void> {
   isLoading.value = true
   error.value = ''
   try {
-    const resp = await fetch('/codex-api/skills-hub')
+    const resp = await appFetch('/codex-api/skills-hub')
     if (!resp.ok) throw new Error(`HTTP ${resp.status}`)
     const data = (await resp.json()) as SkillsHubPayload
     applySkillsPayload(data)
@@ -274,7 +275,7 @@ async function searchSkills(): Promise<void> {
   skillSearchError.value = ''
   try {
     const params = new URLSearchParams({ q: query })
-    const resp = await fetch(`/codex-api/skills-hub/search?${params}`)
+    const resp = await appFetch(`/codex-api/skills-hub/search?${params}`)
     const data = (await resp.json()) as SkillsSearchPayload
     if (!resp.ok) throw new Error(data.error || `HTTP ${resp.status}`)
     const installedByName = new Map(installedSkills.value.map((skill) => [skill.name, skill]))
@@ -297,7 +298,7 @@ async function handleInstall(skill: HubSkill): Promise<void> {
   actionSkillKey.value = `${skill.owner}/${skill.name}`
   isInstallActionInFlight.value = true
   try {
-    const resp = await fetch('/codex-api/skills-hub/install', {
+    const resp = await appFetch('/codex-api/skills-hub/install', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ owner: skill.owner, name: skill.name, source: skill.source }),
@@ -325,7 +326,7 @@ async function handleUninstall(skill: HubSkill): Promise<void> {
   actionSkillKey.value = `${skill.owner}/${skill.name}`
   isUninstallActionInFlight.value = true
   try {
-    const resp = await fetch('/codex-api/skills-hub/uninstall', {
+    const resp = await appFetch('/codex-api/skills-hub/uninstall', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ name: skill.name, path: skill.path }),
@@ -345,13 +346,13 @@ async function handleUninstall(skill: HubSkill): Promise<void> {
 
 async function handleToggleEnabled(skill: HubSkill, enabled: boolean): Promise<void> {
   try {
-    const resp = await fetch('/codex-api/rpc', {
+    const resp = await appFetch('/codex-api/rpc', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ method: 'skills/config/write', params: { path: skill.path, enabled } }),
     })
     if (!resp.ok) throw new Error('Failed to update skill')
-    await fetch('/codex-api/skills-sync/push', { method: 'POST' })
+    await appFetch('/codex-api/skills-sync/push', { method: 'POST' })
     showToast(`${skill.displayName || skill.name} skill ${enabled ? 'enabled' : 'disabled'}`)
     await fetchSkills()
   } catch (e) {

--- a/src/components/content/ThreadComposer.vue
+++ b/src/components/content/ThreadComposer.vue
@@ -421,6 +421,7 @@ import IconTablerMaximize from '../icons/IconTablerMaximize.vue'
 import IconTablerMicrophone from '../icons/IconTablerMicrophone.vue'
 import IconTablerMinimize from '../icons/IconTablerMinimize.vue'
 import IconTablerPlayerStopFilled from '../icons/IconTablerPlayerStopFilled.vue'
+import { appPath } from '../../basePath'
 import ComposerDropdown from './ComposerDropdown.vue'
 import ComposerSearchDropdown from './ComposerSearchDropdown.vue'
 
@@ -1214,7 +1215,7 @@ function skillMarkdownPath(path: string): string {
 function openSkillMarkdown(skill: SkillItem): void {
   const markdownPath = skillMarkdownPath(skill.path)
   if (!markdownPath || typeof window === 'undefined') return
-  window.open(`/codex-local-browse${encodeURI(markdownPath)}`, '_blank', 'noopener,noreferrer')
+  window.open(appPath(`/codex-local-browse${encodeURI(markdownPath)}`), '_blank', 'noopener,noreferrer')
 }
 
 function removeFileAttachment(fsPath: string): void {
@@ -1347,7 +1348,7 @@ async function attachImageFile(file: File, sessionToken: number): Promise<void> 
       {
         id: createAttachmentId(),
         name: normalizedFile.name,
-        url: `/codex-local-image?path=${encodeURIComponent(serverPath)}`,
+        url: appPath(`/codex-local-image?path=${encodeURIComponent(serverPath)}`),
       },
     ]
     recordAttachmentBatchResult('success')

--- a/src/components/content/ThreadConversation.vue
+++ b/src/components/content/ThreadConversation.vue
@@ -923,6 +923,7 @@ import { updateThreadFileChanges } from '../../api/codexGateway'
 import { useFeedbackDiagnostics } from '../../composables/useFeedbackDiagnostics'
 import { useMobile } from '../../composables/useMobile'
 import { copyTextToClipboard, copyTextWithSelectionFallback } from '../../utils/clipboard'
+import { appPath, stripAppBasePath } from '../../basePath'
 
 import IconTablerArrowBackUp from '../icons/IconTablerArrowBackUp.vue'
 import IconTablerArrowUp from '../icons/IconTablerArrowUp.vue'
@@ -2846,19 +2847,19 @@ function toRenderableImageUrl(value: string): string {
     normalized.startsWith('blob:') ||
     normalized.startsWith('http://') ||
     normalized.startsWith('https://') ||
-    normalized.startsWith('/codex-local-image?')
+    stripAppBasePath(normalized).startsWith('/codex-local-image?')
   ) {
     return normalized
   }
 
   if (normalized.startsWith('file://')) {
-    return `/codex-local-image?path=${encodeURIComponent(normalized)}`
+    return appPath(`/codex-local-image?path=${encodeURIComponent(normalized)}`)
   }
 
   const looksLikeUnixAbsolute = normalized.startsWith('/')
   const looksLikeWindowsAbsolute = /^[A-Za-z]:[\\/]/u.test(normalized)
   if (looksLikeUnixAbsolute || looksLikeWindowsAbsolute) {
-    return `/codex-local-image?path=${encodeURIComponent(normalized)}`
+    return appPath(`/codex-local-image?path=${encodeURIComponent(normalized)}`)
   }
 
   return normalized
@@ -2877,7 +2878,7 @@ function toBrowseUrl(pathValue: string): string {
 
   if (looksLikeAbsolutePath(resolved)) {
     const normalizedResolved = resolved.startsWith('/') ? resolved : `/${resolved}`
-    return `/codex-local-browse${encodeURI(normalizedResolved)}`
+    return appPath(`/codex-local-browse${encodeURI(normalizedResolved)}`)
   }
 
   return '#'
@@ -2893,9 +2894,10 @@ function toEditUrlFromBrowseHref(href: string): string {
   if (!normalizedHref) return ''
   try {
     const resolved = new URL(normalizedHref, window.location.href)
-    if (!resolved.pathname.startsWith('/codex-local-browse')) return ''
-    const editPath = `/codex-local-edit${resolved.pathname.slice('/codex-local-browse'.length)}`
-    return `${editPath}${resolved.search}${resolved.hash}`
+    const appRelativePath = stripAppBasePath(resolved.pathname)
+    if (!appRelativePath.startsWith('/codex-local-browse')) return ''
+    const editPath = `/codex-local-edit${appRelativePath.slice('/codex-local-browse'.length)}`
+    return `${appPath(editPath)}${resolved.search}${resolved.hash}`
   } catch {
     return ''
   }

--- a/src/composables/useDesktopState.ts
+++ b/src/composables/useDesktopState.ts
@@ -60,6 +60,7 @@ import type {
   UiThread,
 } from '../types/codex'
 import { getPathParent, isProjectlessChatPath, normalizePathForUi, toProjectName } from '../pathUtils.js'
+import { appPath, stripAppBasePath } from '../basePath'
 
 function flattenThreads(groups: UiProjectGroup[]): UiThread[] {
   return groups.flatMap((group) => group.threads)
@@ -1483,7 +1484,7 @@ export function useDesktopState() {
   function extractLocalImagePathFromUrl(value: string): string {
     try {
       const parsed = new URL(value, 'http://localhost')
-      if (parsed.pathname !== '/codex-local-image') return ''
+      if (stripAppBasePath(parsed.pathname) !== '/codex-local-image') return ''
       return parsed.searchParams.get('path')?.trim() ?? ''
     } catch {
       return ''
@@ -3524,7 +3525,7 @@ export function useDesktopState() {
   }
 
   function toLocalImageUrl(path: string): string {
-    return `/codex-local-image?path=${encodeURIComponent(path)}`
+    return appPath(`/codex-local-image?path=${encodeURIComponent(path)}`)
   }
 
   function toImageGenerationUrl(value: string): string {
@@ -3534,7 +3535,7 @@ export function useDesktopState() {
       trimmed.startsWith('data:') ||
       trimmed.startsWith('http://') ||
       trimmed.startsWith('https://') ||
-      trimmed.startsWith('/codex-local-image?')
+      stripAppBasePath(trimmed).startsWith('/codex-local-image?')
     ) {
       return trimmed
     }

--- a/src/composables/useDictation.ts
+++ b/src/composables/useDictation.ts
@@ -1,4 +1,5 @@
 import { onBeforeUnmount, ref } from 'vue'
+import { appFetch } from '../basePath'
 
 export type DictationState = 'idle' | 'recording' | 'transcribing'
 const DICTATION_SILENCE_THRESHOLD = 0.0025
@@ -224,7 +225,7 @@ export function useDictation(options: {
       requestAbortController = new AbortController()
       transcribeAbortController = requestAbortController
 
-      const response = await fetch('/codex-api/transcribe', {
+      const response = await appFetch('/codex-api/transcribe', {
         method: 'POST',
         body: formData,
         signal: requestAbortController.signal,

--- a/src/composables/useGithubSkillsSync.ts
+++ b/src/composables/useGithubSkillsSync.ts
@@ -1,4 +1,5 @@
 import { computed, ref } from 'vue'
+import { appFetch } from '../basePath'
 
 type ToastType = 'success' | 'error'
 
@@ -77,7 +78,7 @@ export function useGithubSkillsSync(options: UseGithubSkillsSyncOptions) {
 
   async function loadSyncStatus(): Promise<void> {
     try {
-      const resp = await fetch('/codex-api/skills-sync/status')
+      const resp = await appFetch('/codex-api/skills-sync/status')
       if (!resp.ok) return
       const payload = (await resp.json()) as { data?: SkillsSyncStatus }
       if (payload.data) syncStatus.value = payload.data
@@ -88,7 +89,7 @@ export function useGithubSkillsSync(options: UseGithubSkillsSyncOptions) {
 
   async function startGithubLogin(): Promise<void> {
     try {
-      const startResp = await fetch('/codex-api/skills-sync/github/start-login', { method: 'POST' })
+      const startResp = await appFetch('/codex-api/skills-sync/github/start-login', { method: 'POST' })
       const startData = (await startResp.json()) as { data?: { device_code: string; user_code: string; verification_uri: string; interval?: number } }
       if (!startResp.ok || !startData.data) throw new Error('Failed to start GitHub login')
       deviceLogin.value = startData.data
@@ -97,7 +98,7 @@ export function useGithubSkillsSync(options: UseGithubSkillsSyncOptions) {
       let loggedIn = false
       for (let i = 0; i < maxAttempts; i++) {
         await new Promise((resolve) => setTimeout(resolve, waitMs))
-        const completeResp = await fetch('/codex-api/skills-sync/github/complete-login', {
+        const completeResp = await appFetch('/codex-api/skills-sync/github/complete-login', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ deviceCode: startData.data.device_code }),
@@ -134,7 +135,7 @@ export function useGithubSkillsSync(options: UseGithubSkillsSyncOptions) {
       if (!token) {
         throw new Error('GitHub access token missing from Firebase login')
       }
-      const resp = await fetch('/codex-api/skills-sync/github/token-login', {
+      const resp = await appFetch('/codex-api/skills-sync/github/token-login', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ token }),
@@ -156,7 +157,7 @@ export function useGithubSkillsSync(options: UseGithubSkillsSyncOptions) {
     syncActionStatus.value = 'pull-started'
     syncActionInFlight.value = 'pull'
     try {
-      const resp = await fetch('/codex-api/skills-sync/pull', { method: 'POST' })
+      const resp = await appFetch('/codex-api/skills-sync/pull', { method: 'POST' })
       const data = (await resp.json()) as { ok?: boolean; error?: string }
       if (!resp.ok || !data.ok) throw new Error(data.error || 'Failed to pull synced skills')
       await options.onPulled()
@@ -177,7 +178,7 @@ export function useGithubSkillsSync(options: UseGithubSkillsSyncOptions) {
     syncActionStatus.value = 'push-started'
     syncActionInFlight.value = 'push'
     try {
-      const resp = await fetch('/codex-api/skills-sync/push', { method: 'POST' })
+      const resp = await appFetch('/codex-api/skills-sync/push', { method: 'POST' })
       const data = (await resp.json()) as { ok?: boolean; error?: string }
       if (!resp.ok || !data.ok) throw new Error(data.error || 'Failed to push synced skills')
       syncActionStatus.value = 'push-success'
@@ -197,7 +198,7 @@ export function useGithubSkillsSync(options: UseGithubSkillsSyncOptions) {
     syncActionStatus.value = 'startup-sync-started'
     syncActionInFlight.value = 'startup-sync'
     try {
-      const resp = await fetch('/codex-api/skills-sync/startup-sync', { method: 'POST' })
+      const resp = await appFetch('/codex-api/skills-sync/startup-sync', { method: 'POST' })
       const data = (await resp.json()) as { ok?: boolean; error?: string }
       if (!resp.ok || !data.ok) throw new Error(data.error || 'Failed to run startup sync')
       await options.onPulled()
@@ -216,7 +217,7 @@ export function useGithubSkillsSync(options: UseGithubSkillsSyncOptions) {
 
   async function logoutGithub(): Promise<void> {
     try {
-      const resp = await fetch('/codex-api/skills-sync/github/logout', { method: 'POST' })
+      const resp = await appFetch('/codex-api/skills-sync/github/logout', { method: 'POST' })
       const data = (await resp.json()) as { ok?: boolean; error?: string }
       if (!resp.ok || !data.ok) throw new Error(data.error || 'Failed to logout GitHub')
       await loadSyncStatus()

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,7 @@ import router from './router'
 import './style.css'
 import { t } from './composables/useUiLanguage'
 import { installFeedbackDiagnostics } from './composables/useFeedbackDiagnostics'
+import { appPath } from './basePath'
 
 console.log('Welcome to codexui. github: https://github.com/friuns2/codexUI')
 
@@ -13,7 +14,7 @@ createApp(App).use(router).mount('#app')
 
 if ('serviceWorker' in navigator && import.meta.env.PROD) {
   window.addEventListener('load', () => {
-    navigator.serviceWorker.register('/sw.js').catch((error) => {
+    navigator.serviceWorker.register(appPath('/sw.js')).catch((error) => {
       console.error(t('Service worker registration failed.'), error)
     })
   })

--- a/src/server/authMiddleware.ts
+++ b/src/server/authMiddleware.ts
@@ -135,11 +135,11 @@ function pruneExpiredSessions(validTokens: Map<string, number>): boolean {
   return changed
 }
 
-function buildSessionCookie(token: string, expiresAt: number): string {
+function buildSessionCookie(token: string, expiresAt: number, cookiePath: string): string {
   const maxAgeSeconds = Math.max(0, Math.floor((expiresAt - Date.now()) / 1000))
   return [
     `${TOKEN_COOKIE}=${token}`,
-    'Path=/',
+    `Path=${cookiePath}`,
     'HttpOnly',
     'SameSite=Lax',
     `Max-Age=${String(maxAgeSeconds)}`,
@@ -205,7 +205,7 @@ const errEl=document.getElementById('err');
 form.addEventListener('submit',async e=>{
   e.preventDefault();
   errEl.style.display='none';
-  const res=await fetch('/auth/login',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({password:document.getElementById('pw').value})});
+  const res=await fetch('auth/login',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({password:document.getElementById('pw').value})});
   if(res.ok){window.location.reload()}else{errEl.style.display='block';document.getElementById('pw').value='';document.getElementById('pw').focus()}
 });
 </script>
@@ -221,7 +221,8 @@ export type AuthSession = {
   isRequestAuthorized: (req: IncomingMessage) => boolean
 }
 
-export function createAuthSession(password: string): AuthSession {
+export function createAuthSession(password: string, options?: { cookiePath?: string }): AuthSession {
+  const cookiePath = options?.cookiePath || '/'
   const validTokens = readPersistedSessions()
   if (pruneExpiredSessions(validTokens)) {
     tryPersistSessions(validTokens)
@@ -262,7 +263,7 @@ export function createAuthSession(password: string): AuthSession {
           const expiresAt = Date.now() + SESSION_TTL_MS
           validTokens.set(token, expiresAt)
           tryPersistSessions(validTokens)
-          res.setHeader('Set-Cookie', buildSessionCookie(token, expiresAt))
+          res.setHeader('Set-Cookie', buildSessionCookie(token, expiresAt, cookiePath))
           res.json({ ok: true })
         } catch {
           res.status(500).json({ error: 'Failed to create login session' })
@@ -279,8 +280,8 @@ export function createAuthSession(password: string): AuthSession {
         const expiresAt = Date.now() + SESSION_TTL_MS
         validTokens.set(token, expiresAt)
         tryPersistSessions(validTokens)
-        res.setHeader('Set-Cookie', buildSessionCookie(token, expiresAt))
-        res.redirect(302, '/')
+        res.setHeader('Set-Cookie', buildSessionCookie(token, expiresAt, cookiePath))
+        res.redirect(302, cookiePath === '/' ? '/' : `${cookiePath}/`)
         return
       }
     }

--- a/src/server/httpServer.ts
+++ b/src/server/httpServer.ts
@@ -76,7 +76,7 @@ function readWildcardPathParam(value: unknown): string {
 
 export function createServer(options: ServerOptions = {}): ServerInstance {
   const app = express()
-  const basePath = normalizeBasePath(options.basePath ?? process.env.CODEXUI_BASE_PATH)
+  const basePath = normalizeBasePath(options.basePath)
   const bridge = createCodexBridgeMiddleware()
   const authSession = options.password ? createAuthSession(options.password, { cookiePath: basePath || '/' }) : null
 

--- a/src/server/httpServer.ts
+++ b/src/server/httpServer.ts
@@ -1,13 +1,14 @@
 import { fileURLToPath } from 'node:url'
 import { dirname, extname, isAbsolute, join } from 'node:path'
 import type { Server as HttpServer, IncomingMessage } from 'node:http'
-import { existsSync } from 'node:fs'
+import { existsSync, readFileSync } from 'node:fs'
 import { writeFile, stat } from 'node:fs/promises'
 import express, { type Express } from 'express'
 import { createCodexBridgeMiddleware } from './codexAppServerBridge.js'
 import { createAuthSession } from './authMiddleware.js'
 import { createDirectoryListingHtml, createTextEditorHtml, decodeBrowsePath, getLocalDirectoryListing, isTextEditableFile, normalizeLocalPath } from './localBrowseUi.js'
 import { WebSocketServer, type WebSocket } from 'ws'
+import { normalizeBasePath } from '../basePath.js'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const distDir = join(__dirname, '..', 'dist')
@@ -15,6 +16,7 @@ const spaEntryFile = join(distDir, 'index.html')
 
 export type ServerOptions = {
   password?: string
+  basePath?: string
 }
 
 export type ServerInstance = {
@@ -74,8 +76,9 @@ function readWildcardPathParam(value: unknown): string {
 
 export function createServer(options: ServerOptions = {}): ServerInstance {
   const app = express()
+  const basePath = normalizeBasePath(options.basePath ?? process.env.CODEXUI_BASE_PATH)
   const bridge = createCodexBridgeMiddleware()
-  const authSession = options.password ? createAuthSession(options.password) : null
+  const authSession = options.password ? createAuthSession(options.password, { cookiePath: basePath || '/' }) : null
 
   // 1. Auth middleware (if password is set)
   if (authSession) {
@@ -163,7 +166,7 @@ export function createServer(options: ServerOptions = {}): ServerInstance {
       const fileStat = await stat(localPath)
       res.setHeader('Cache-Control', 'private, no-store')
       if (fileStat.isDirectory()) {
-        const html = await createDirectoryListingHtml(localPath, { newProjectName })
+        const html = await createDirectoryListingHtml(localPath, { newProjectName, basePath })
         res.status(200).type('text/html; charset=utf-8').send(html)
         return
       }
@@ -191,7 +194,7 @@ export function createServer(options: ServerOptions = {}): ServerInstance {
         res.status(400).json({ error: 'Expected file path.' })
         return
       }
-      const html = await createTextEditorHtml(localPath)
+      const html = await createTextEditorHtml(localPath, { basePath })
       res.status(200).type('text/html; charset=utf-8').send(html)
     } catch {
       res.status(404).json({ error: 'File not found.' })
@@ -219,10 +222,13 @@ export function createServer(options: ServerOptions = {}): ServerInstance {
   })
 
   const hasFrontendAssets = existsSync(spaEntryFile)
+  const renderedSpaHtml = hasFrontendAssets
+    ? readFileSync(spaEntryFile, 'utf8').replace('__CODEXUI_BASE_PATH__', basePath)
+    : ''
 
   // 8. Static files from Vue build
   if (hasFrontendAssets) {
-    app.use(express.static(distDir))
+    app.use(express.static(distDir, { index: false }))
   }
 
   // 9. SPA fallback
@@ -241,23 +247,33 @@ export function createServer(options: ServerOptions = {}): ServerInstance {
       return
     }
 
-    res.sendFile(spaEntryFile, (error) => {
-      if (!error) return
-      if (!res.headersSent) {
-        res.status(404).type('text/html; charset=utf-8').send(renderFrontendMissingHtml('Frontend entry file not found.'))
-      }
-    })
+    res.status(200).type('text/html; charset=utf-8').send(renderedSpaHtml)
   })
 
+  const hostApp = express()
+  if (basePath) {
+    hostApp.use((req, res, next) => {
+      const pathname = new URL(req.originalUrl, 'http://localhost').pathname
+      if ((req.method === 'GET' || req.method === 'HEAD') && pathname === basePath) {
+        res.redirect(308, `${basePath}/`)
+        return
+      }
+      next()
+    })
+    hostApp.use(basePath, app)
+  }
+  // Keep root routes available for ingress controllers that strip the workspace prefix.
+  hostApp.use(app)
+
   return {
-    app,
+    app: hostApp,
     dispose: () => bridge.dispose(),
     attachWebSocket: (server: HttpServer) => {
       const wss = new WebSocketServer({ noServer: true })
 
       server.on('upgrade', (req: IncomingMessage, socket, head) => {
         const url = new URL(req.url ?? '', 'http://localhost')
-        if (url.pathname !== '/codex-api/ws') {
+        if (url.pathname !== '/codex-api/ws' && url.pathname !== `${basePath}/codex-api/ws`) {
           return
         }
 

--- a/src/server/localBrowseUi.ts
+++ b/src/server/localBrowseUi.ts
@@ -1,5 +1,6 @@
 import { dirname, extname, join } from 'node:path'
 import { open, readFile, readdir, stat } from 'node:fs/promises'
+import { appPath } from '../basePath.js'
 
 type DirectoryItem = {
   name: string
@@ -131,16 +132,16 @@ function normalizeNewProjectName(value: string): string {
   return value.trim().replace(/[\\/]+/gu, '').trim()
 }
 
-function toBrowseHref(pathValue: string, newProjectName = ''): string {
+function toBrowseHref(pathValue: string, newProjectName = '', basePath = ''): string {
   const normalizedName = normalizeNewProjectName(newProjectName)
   const query = normalizedName ? `?newProjectName=${encodeURIComponent(normalizedName)}` : ''
-  return `/codex-local-browse${encodeURI(pathValue)}${query}`
+  return appPath(`/codex-local-browse${encodeURI(pathValue)}${query}`, basePath)
 }
 
-function toEditHref(pathValue: string, newProjectName = ''): string {
+function toEditHref(pathValue: string, newProjectName = '', basePath = ''): string {
   const normalizedName = normalizeNewProjectName(newProjectName)
   const query = normalizedName ? `?newProjectName=${encodeURIComponent(normalizedName)}` : ''
-  return `/codex-local-edit${encodeURI(pathValue)}${query}`
+  return appPath(`/codex-local-edit${encodeURI(pathValue)}${query}`, basePath)
 }
 
 function escapeForInlineScriptString(value: string): string {
@@ -240,22 +241,23 @@ export async function getLocalDirectoryListing(
   }
 }
 
-export async function createDirectoryListingHtml(localPath: string, options?: { newProjectName?: string }): Promise<string> {
+export async function createDirectoryListingHtml(localPath: string, options?: { newProjectName?: string; basePath?: string }): Promise<string> {
   const newProjectName = normalizeNewProjectName(options?.newProjectName ?? '')
+  const basePath = options?.basePath ?? ''
   const items = await getDirectoryItems(localPath)
   const parentPath = dirname(localPath)
   const rows = items
     .map((item) => {
       const suffix = item.isDirectory ? '/' : ''
       const editAction = item.editable
-        ? ` <a class="icon-btn" aria-label="Edit ${escapeHtml(item.name)}" href="${escapeHtml(toEditHref(item.path, newProjectName))}" title="Edit">✏️</a>`
+        ? ` <a class="icon-btn" aria-label="Edit ${escapeHtml(item.name)}" href="${escapeHtml(toEditHref(item.path, newProjectName, basePath))}" title="Edit">✏️</a>`
         : ''
-      return `<li class="file-row"><a class="file-link" href="${escapeHtml(toBrowseHref(item.path, newProjectName))}">${escapeHtml(item.name)}${suffix}</a><span class="row-actions">${editAction}</span></li>`
+      return `<li class="file-row"><a class="file-link" href="${escapeHtml(toBrowseHref(item.path, newProjectName, basePath))}">${escapeHtml(item.name)}${suffix}</a><span class="row-actions">${editAction}</span></li>`
     })
     .join('\n')
 
   const parentLink = localPath !== parentPath
-    ? `<a class="header-parent-link" href="${escapeHtml(toBrowseHref(parentPath, newProjectName))}">..</a>`
+    ? `<a class="header-parent-link" href="${escapeHtml(toBrowseHref(parentPath, newProjectName, basePath))}">..</a>`
     : ''
   const pickerSummary = newProjectName
     ? `<p class="picker-summary">Browse to the parent folder where you want to create <strong>${escapeHtml(newProjectName)}</strong>, or open the current folder directly.</p>`
@@ -331,7 +333,7 @@ export async function createDirectoryListingHtml(localPath: string, options?: { 
       button.disabled = true;
       status.textContent = statusText;
       try {
-        const response = await fetch('/codex-api/project-root', {
+        const response = await fetch(${escapeForInlineScriptString(appPath('/codex-api/project-root', basePath))}, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
@@ -346,7 +348,7 @@ export async function createDirectoryListingHtml(localPath: string, options?: { 
           return;
         }
         status.textContent = 'Folder opened. Returning to Codex...';
-        const nextUrl = '/?openProjectPath=' + encodeURIComponent(path) + '#/';
+        const nextUrl = ${escapeForInlineScriptString(appPath('/', basePath))} + '?openProjectPath=' + encodeURIComponent(path) + '#/';
         window.location.assign(nextUrl);
       } catch {
         status.textContent = errorText;
@@ -358,7 +360,7 @@ export async function createDirectoryListingHtml(localPath: string, options?: { 
 </html>`
 }
 
-export async function createTextEditorHtml(localPath: string): Promise<string> {
+export async function createTextEditorHtml(localPath: string, options?: { basePath?: string }): Promise<string> {
   const content = await readFile(localPath, 'utf8')
   const parentPath = dirname(localPath)
   const language = languageForPath(localPath)
@@ -388,7 +390,7 @@ export async function createTextEditorHtml(localPath: string): Promise<string> {
 <body>
   <div class="toolbar">
     <div class="row">
-      <a href="${escapeHtml(toBrowseHref(parentPath))}">Back</a>
+      <a href="${escapeHtml(toBrowseHref(parentPath, '', options?.basePath))}">Back</a>
       <button id="saveBtn" type="button">Save</button>
       <span id="status"></span>
     </div>

--- a/tests.md
+++ b/tests.md
@@ -22,7 +22,7 @@ This file is the manual test index. Detailed regression and feature verification
 | [Thread Loading, Streaming, and State](tests/thread-loading-state/index.md) | 26 | Thread list/detail loading, pagination, selected-thread stability, streaming scroll behavior, live-state reads, and missing-thread handling. |
 | [Providers and Models](tests/providers-models/index.md) | 24 | Provider selectors, model menus, OpenRouter, OpenCode Zen, custom endpoints, Responses/Completions format, and model refresh behavior. |
 | [Auth and Docker Runtime](tests/auth-docker-runtime/index.md) | 12 | Codex auth, Docker-packaged runtime cases, copied auth behavior, invalid auth errors, and auth-aware provider fallback. |
-| [CLI, Network, and Platform](tests/cli-network-platform/index.md) | 17 | CLI startup, dev scripts, npx, Tailscale, Cloudflare tunnels, Windows, Android, Termux, and platform packaging behavior. |
+| [CLI, Network, and Platform](tests/cli-network-platform/index.md) | 18 | CLI startup, dev scripts, npx, Tailscale, Cloudflare tunnels, Windows, Android, Termux, and platform packaging behavior. |
 | [Git, Worktrees, and Rollback](tests/git-worktrees-rollback/index.md) | 25 | Branch controls, worktree creation, rollback commits, changed-files panels, file browser links, and rollback debug behavior. |
 | [Accounts, Feedback, and Observability](tests/accounts-feedback-observability/index.md) | 14 | Account panels, quota refresh, feedback diagnostics, Sentry, browser profiling, API perf logs, and Qodo diagnostic fixes. |
 | [Theme, Layout, and Terminal](tests/theme-layout-terminal/index.md) | 16 | Light/dark theme regressions, responsive layout, terminal UI, mobile keyboard behavior, dialog sizing, and visual alignment. |

--- a/tests/cli-network-platform/configurable-reverse-proxy-base-path.md
+++ b/tests/cli-network-platform/configurable-reverse-proxy-base-path.md
@@ -1,0 +1,35 @@
+# Configurable reverse-proxy base path
+
+## Feature/change
+
+`CODEXUI_BASE_PATH` scopes frontend assets, API requests, local-file links, SSE, and WebSocket traffic below a workspace-specific URL prefix.
+
+## Prerequisites/setup
+
+- A production build of the app
+- A test workspace id such as `workspace-a`
+- An unused local port
+
+## Actions
+
+1. Start the built CLI with `CODEXUI_BASE_PATH=/codex/workspace-a` on the unused port.
+2. Open `/codex/workspace-a/` and inspect the loaded document, manifest, icons, JavaScript, and CSS requests.
+3. Trigger an RPC call and inspect its HTTP URL.
+4. Inspect the realtime connection URL; if WebSocket is unavailable, inspect the SSE fallback URL.
+5. Open a rendered local image and a local file-browser link.
+6. Request `/codex/workspace-a` without a trailing slash.
+7. Repeat one API request against the unprefixed upstream route to model an ingress that strips the workspace prefix.
+
+## Expected results
+
+- Assets and PWA resources load below `/codex/workspace-a/` without requests escaping to the hostname root.
+- RPC uses `/codex/workspace-a/codex-api/rpc`.
+- Realtime uses `/codex/workspace-a/codex-api/ws` or `/codex/workspace-a/codex-api/events`.
+- Local image, browser, editor, and directory-picker URLs retain the prefix.
+- The path without a trailing slash redirects to `/codex/workspace-a/`.
+- The server also accepts the unprefixed API request after ingress-style prefix stripping.
+- Existing root deployment behavior remains unchanged when `CODEXUI_BASE_PATH` is unset.
+
+## Rollback/cleanup
+
+Stop the test server and unset `CODEXUI_BASE_PATH`.

--- a/tests/cli-network-platform/configurable-reverse-proxy-base-path.md
+++ b/tests/cli-network-platform/configurable-reverse-proxy-base-path.md
@@ -2,7 +2,7 @@
 
 ## Feature/change
 
-`CODEXUI_BASE_PATH` scopes frontend assets, API requests, local-file links, SSE, and WebSocket traffic below a workspace-specific URL prefix.
+The `--base-path` CLI option scopes frontend assets, API requests, local-file links, SSE, and WebSocket traffic below a workspace-specific URL prefix.
 
 ## Prerequisites/setup
 
@@ -12,7 +12,7 @@
 
 ## Actions
 
-1. Start the built CLI with `CODEXUI_BASE_PATH=/codex/workspace-a` on the unused port.
+1. Start the built CLI with `--base-path /codex/workspace-a` on the unused port.
 2. Open `/codex/workspace-a/` and inspect the loaded document, manifest, icons, JavaScript, and CSS requests.
 3. Trigger an RPC call and inspect its HTTP URL.
 4. Inspect the realtime connection URL; if WebSocket is unavailable, inspect the SSE fallback URL.
@@ -28,8 +28,8 @@
 - Local image, browser, editor, and directory-picker URLs retain the prefix.
 - The path without a trailing slash redirects to `/codex/workspace-a/`.
 - The server also accepts the unprefixed API request after ingress-style prefix stripping.
-- Existing root deployment behavior remains unchanged when `CODEXUI_BASE_PATH` is unset.
+- Existing root deployment behavior remains unchanged when `--base-path` is omitted.
 
 ## Rollback/cleanup
 
-Stop the test server and unset `CODEXUI_BASE_PATH`.
+Stop the test server.

--- a/tests/cli-network-platform/index.md
+++ b/tests/cli-network-platform/index.md
@@ -26,3 +26,4 @@ Return to the [manual test index](../../tests.md).
 | [Feature: CLI auto-stars friuns2/codexui on startup (best-effort)](cli-auto-stars-friuns2-codexui-on-startup-best-effort.md) |
 | [Startup welcome log uses repository GitHub URL](startup-welcome-log-uses-repository-github-url.md) |
 | [Home route no longer crashes on dev startup](home-route-no-longer-crashes-on-dev-startup.md) |
+| [Configurable reverse-proxy base path](configurable-reverse-proxy-base-path.md) |

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -102,7 +102,7 @@ function resolveViteRollbackDebugFallback(): string {
 }
 
 const viteRollbackDebugFallback = resolveViteRollbackDebugFallback();
-const configuredBasePath = normalizeBasePath(process.env.CODEXUI_BASE_PATH);
+const configuredBasePath = normalizeBasePath(process.env.VITE_CODEXUI_BASE_PATH);
 
 export default defineConfig({
   base: configuredBasePath ? `${configuredBasePath}/` : "./",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,6 +9,7 @@ import { stat, writeFile } from "node:fs/promises";
 import { basename, extname, isAbsolute } from "node:path";
 import { WebSocketServer, type WebSocket } from "ws";
 import pkg from "./package.json";
+import { normalizeBasePath } from "./src/basePath";
 
 const IMAGE_CONTENT_TYPES: Record<string, string> = {
   ".avif": "image/avif",
@@ -101,12 +102,15 @@ function resolveViteRollbackDebugFallback(): string {
 }
 
 const viteRollbackDebugFallback = resolveViteRollbackDebugFallback();
+const configuredBasePath = normalizeBasePath(process.env.CODEXUI_BASE_PATH);
 
 export default defineConfig({
+  base: configuredBasePath ? `${configuredBasePath}/` : "./",
   define: {
     "import.meta.env.VITE_WORKTREE_NAME": JSON.stringify(worktreeName),
     "import.meta.env.VITE_APP_VERSION": JSON.stringify(appVersion),
     "import.meta.env.VITE_ROLLBACK_DEBUG_FALLBACK": JSON.stringify(viteRollbackDebugFallback),
+    "import.meta.env.VITE_CODEXUI_BASE_PATH": JSON.stringify(configuredBasePath),
   },
   server: {
     host: "0.0.0.0",
@@ -147,7 +151,7 @@ export default defineConfig({
 
             httpServer.on("upgrade", (req, socket, head) => {
               const requestUrl = new URL(req.url ?? "", "http://localhost");
-              if (requestUrl.pathname !== "/codex-api/ws") return;
+              if (requestUrl.pathname !== `${configuredBasePath}/codex-api/ws`) return;
               wss.handleUpgrade(req, socket, head, (ws: WebSocket) => {
                 wss.emit("connection", ws, req);
               });
@@ -174,6 +178,17 @@ export default defineConfig({
               wss.close();
             });
           }
+        }
+        if (configuredBasePath) {
+          server.middlewares.use((req, _res, next) => {
+            if (req.url?.startsWith(`${configuredBasePath}/`)) {
+              const unprefixedUrl = req.url.slice(configuredBasePath.length);
+              if (unprefixedUrl.startsWith('/codex-api/') || unprefixedUrl.startsWith('/codex-local-')) {
+                req.url = unprefixedUrl;
+              }
+            }
+            next();
+          });
         }
         server.middlewares.use((req, res, next) => {
           if (!req.url || (req.method !== "GET" && req.method !== "HEAD")) return next();
@@ -285,7 +300,7 @@ export default defineConfig({
             const fileStat = await stat(localPath);
             res.setHeader("Cache-Control", "private, no-store");
             if (fileStat.isDirectory()) {
-              const html = await createDirectoryListingHtml(localPath, { newProjectName });
+              const html = await createDirectoryListingHtml(localPath, { newProjectName, basePath: configuredBasePath });
               res.statusCode = 200;
               res.setHeader("Content-Type", "text/html; charset=utf-8");
               res.end(html);
@@ -326,7 +341,7 @@ export default defineConfig({
               res.end(JSON.stringify({ error: "Expected file path." }));
               return;
             }
-            const html = await createTextEditorHtml(localPath);
+            const html = await createTextEditorHtml(localPath, { basePath: configuredBasePath });
             res.statusCode = 200;
             res.setHeader("Content-Type", "text/html; charset=utf-8");
             res.end(html);


### PR DESCRIPTION
## Summary

- Add a `--base-path <path>` CLI option so a single build can be served below an arbitrary reverse-proxy path prefix.
- Resolve frontend asset, API, WebSocket/SSE, PWA, service-worker, local-file, and login URLs relative to that prefix instead of the hostname root.
- Scope the session cookie and post-login redirect to the prefix, and accept both prefixed and prefix-stripped requests so either ingress style works.
- Keep root (`/`) deployments byte-for-byte unchanged when `--base-path` is omitted.

## Motivation

CodexApp currently assumes it owns the hostname root. That holds for `localhost`, LAN, and the cloudflared tunnel, but not for a headless deployment — running `codexapp` as a Kubernetes workload behind a shared Ingress, where each user's instance is exposed at `https://host/codex/<workspace-id>/` rather than on its own hostname. Without a prefix-aware build, asset, RPC, and WebSocket requests escape to `/`, and the session cookie is set at `Path=/`, so instances collide on a shared host.

## What changed

- `src/basePath.ts` (new): `normalizeBasePath`, `getAppBasePath`, `appPath`, `stripAppBasePath`, `appFetch`, `appWebSocketUrl`. Normalization rejects query strings, fragments, backslashes, whitespace, and `.`/`..` segments.
- `src/cli/index.ts`: `--base-path` option; startup URLs, tunnel QR URL, and `--open` target include the prefix.
- `src/server/httpServer.ts`: mounts the app under the prefix on a host app, `308`-redirects the bare prefix to the trailing-slash form, and serves `index.html` with the prefix injected into a `codexui-base-path` meta tag (so one build works at any prefix). The unprefixed app stays mounted for prefix-stripping ingresses.
- `src/server/authMiddleware.ts`: cookie `Path` and the post-login redirect follow the prefix; the login form posts to a relative `auth/login`.
- `index.html`, `public/manifest.webmanifest`, `public/sw.js`: relative asset/manifest/icon references; the service worker derives its base from `registration.scope` and namespaces its cache per prefix (`codexweb-shell-v3:<prefix>`), cleaning up only its own generations.
- Frontend call sites (`codexGateway`, `codexRpcClient`, `normalizers/v2`, `useDesktopState`, `useDictation`, `useGithubSkillsSync`, `DirectoryHub`, `SkillsHub`, `SkillCard`, `SkillDetailModal`, `ThreadComposer`, `ThreadConversation`, `App.vue`, `main.ts`) go through `appFetch`/`appPath`/`appWebSocketUrl`.
- `scripts/dev.cjs` + `vite.config.ts`: `--base-path` in dev forwards to Vite as `VITE_CODEXUI_BASE_PATH`; production assets emit relative paths.
- Docs: README "Reverse proxy path prefix" section; manual test doc `tests/cli-network-platform/configurable-reverse-proxy-base-path.md`.

## Relationship to #213

#213 ("Support reverse-proxy base paths") is open and covers overlapping ground — this PR touches nearly the same file set. The approaches differ:

| | #213 | this PR |
|---|---|---|
| URL helper | `src/api/appUrl.ts`, resolved from the document base URL | `src/basePath.ts`, resolved from a server-injected meta tag with a `VITE_CODEXUI_BASE_PATH` fallback |
| Server-side prefix | none | `--base-path` CLI option; app mounted under the prefix |
| Cookie / redirect scoping | not addressed | cookie `Path` and post-login redirect scoped to the prefix |
| Prefix-stripping ingress | n/a | unprefixed routes remain mounted |
| Dev-server support | n/a | `pnpm run dev --base-path ...` |
| Docs / manual tests | n/a | README section + `tests/cli-network-platform/` doc |

Happy to go whichever way you prefer: land this instead, rebase this on top of #213 so it only contributes the server-side `--base-path` option and cookie scoping, or close this if #213 plus a follow-up is the better shape. Just say which and I'll do the work.

## Verification

- `pnpm run test:unit` — 16 files, 152 tests passed (includes the new `src/basePath.test.ts`, 6 cases).
- `pnpm run build` — `vue-tsc --noEmit` + `vite build` + `tsup` all passed.
- Live production CLI, `--base-path /codex/workspace-a --no-tunnel --no-login --no-password --port 5931`:
  - `GET /codex/workspace-a/` → `200`
  - `GET /codex/workspace-a` (no trailing slash) → `308` with `Location: /codex/workspace-a/`
  - served HTML references `./assets/index-*.js`, `./assets/index-*.css`, `./manifest.webmanifest`, `./icons/*` — no request escapes to the hostname root
  - `GET /codex/workspace-a/manifest.webmanifest` → `200`; `GET /codex/workspace-a/sw.js` → `200`
  - `GET /codex/workspace-a/codex-api/skills-sync/status` → `200`
  - `GET /codex-api/skills-sync/status` (ingress-stripped form) → `200`
- Live production CLI with `--password` and `--base-path /codex/ws-b`, non-local `Host`: `POST /codex/ws-b/auth/login` → `200` with `Set-Cookie: portal_session=...; Path=/codex/ws-b; HttpOnly; SameSite=Lax`.
- Manual test steps recorded in `tests/cli-network-platform/configurable-reverse-proxy-base-path.md`.

Not measured in this run: browser-driven verification of the WebSocket/SSE realtime URL, PWA install, and local-image/editor links under a prefix. Those paths go through the same `appPath`/`appWebSocketUrl` helpers as the verified HTTP routes, and the steps are written up in the manual test doc.

## Performance audit

No new requests, filesystem operations, polling, fanout, or payload copies. Specifically:

- `index.html` is read once at server startup and the prefix substitution is done once; the SPA fallback then sends a cached string instead of the previous per-request `res.sendFile`, which removes a `stat`/open per SPA navigation. `express.static` is set to `{ index: false }` so the prefix-injected entry always wins.
- The prefix mount adds one Express router layer and, when a prefix is set, one bare-prefix equality check per request.
- Client-side, `appPath` adds a `startsWith` check plus at most one string concatenation per URL. The ambient prefix is resolved once and cached (`getAppBasePath`), so URL building does not re-query the DOM or re-run normalization per call; the meta tag is injected before any script runs and cannot change afterwards.
- Service worker: the cache key is now namespaced per prefix, so a client switching prefixes populates a separate cache rather than invalidating a shared one. The `v2` → `v3` bump means one cold shell fetch on first load after upgrade.
- No change to startup, thread loading, realtime rendering, or module loading beyond the above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for hosting the Codex UI under a configurable reverse-proxy path using `--base-path`.
  * Updated API, WebSocket, asset, authentication, local file, and browser navigation URLs to work with prefixed deployments.
  * Added redirects and access URLs that include the configured path.

* **Documentation**
  * Documented reverse-proxy path configuration and added manual testing guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->